### PR TITLE
fix: standardize on plural "Helpers" naming convention

### DIFF
--- a/src/adrs/1146361044/README.md
+++ b/src/adrs/1146361044/README.md
@@ -28,4 +28,5 @@ debate in the long-term.
 
 ## Resolution
 
-- You **MUST** use `Helper(s)` over `Util` across all the codebases.
+- You **MUST** use `Helpers` over `Util` across all the codebases.
+- You **MUST** use the plural `Helpers` as the preferred naming convention.


### PR DESCRIPTION
Signed-off-by: Yordis Prieto <yordis.prieto@gmail.com>
