### PR TITLE
[ADR] Annotations and Transient Annotations

### DIFF
--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -1,0 +1,143 @@
+---
+id: '5177934677'
+title: Annotations and Transient Annotations
+state: Draft
+created: 2026-06-28
+tags: [annotations, metadata, event-sourcing, eda]
+category: Platform
+---
+
+# Annotations and Transient Annotations
+
+## Context
+
+Records that move through our systems (events, commands, requests,
+projections, resources) need a place to carry caller-attached metadata that the
+platform itself does not interpret. Examples of the *shape* of need (not an
+enumeration of keys) include: cross-cutting observability context, write-time
+plumbing, caller-owned domain tags, and platform cross-cutting concerns that
+are not first-class envelope fields.
+
+Two questions have to be answered consistently across every record type:
+
+1. **Who owns which keys**, so callers from different systems and teams can
+   attach metadata without colliding.
+2. **How long does an attached entry live**, so storage knows what to persist,
+   and projections know what to copy onto downstream resources.
+
+Existing precedents were considered:
+
+- Kubernetes splits metadata into `labels` (selectable, indexed) and
+  `annotations` (opaque, free-form). The split exists because the API server
+  is the selector engine and has to index a bounded namespace cheaply. We do
+  not have a platform-level selector engine, and we do not know our query
+  patterns up front. Adopting the `labels`/`annotations` split would be
+  ceremony without a corresponding system behavior.
+- CloudEvents, NATS headers, Kafka headers, AMQP application properties, and
+  HTTP headers all use a single flat map with a reserved-prefix convention.
+- Event-sourced systems consistently distinguish between metadata that is
+  part of the event's permanent record and metadata that is attached only for
+  the moment of delivery (tracing context, idempotency, retry plumbing). This
+  distinction maps to real, irreversible system behaviors (persistence and
+  projection), and is decided by the caller at write time.
+
+The axis that earns its keep in our environment is **lifetime**, not
+selectability.
+
+This ADR defines only the **specification** of the annotation namespace. It
+does not enumerate which keys exist, where any particular concern (tracing,
+idempotency, correlation, etc.) should be placed, or how individual
+projections behave. Those are caller and consumer decisions applied using
+this specification. First-class envelope fields (record identifiers, types,
+timestamps, schema versions, causation, aggregate identity, and similar
+platform-interpreted fields) are out of scope and are governed elsewhere.
+
+## Resolution
+
+Records expose two sibling fields with identical shape and identical key
+rules, distinguished only by lifetime:
+
+```
+annotations:           { <key>: <string>, ... }
+transient_annotations: { <key>: <string>, ... }
+```
+
+### Shape
+
+- Both fields are maps of string key to string value.
+- Values are **opaque to the platform**. The platform does not parse,
+  validate, or interpret values. Callers that need structured values
+  `MUST` encode them as strings (for example, JSON-encoded).
+- Both fields are optional. Absence and an empty map are equivalent.
+
+### Key syntax
+
+Keys follow the Kubernetes label key syntax, by reference:
+
+- A key is either `<name>` or `<prefix>/<name>`.
+- `<prefix>`, when present, `MUST` be a DNS subdomain (lowercase
+  alphanumerics, `-`, and `.`; segments separated by `.`; total length
+  `<= 253` characters).
+- `<name>` `MUST` be `1..63` characters, beginning and ending with an
+  alphanumeric, with `-`, `_`, and `.` permitted in between.
+
+### Ownership and reservation
+
+- A prefix `MUST` be a DNS subdomain owned by the writer.
+- Unprefixed keys belong to the caller's own namespace and `MUST NOT` be
+  written by the platform.
+- Keys under a platform-owned prefix are reserved for that platform.
+  Consumers `MUST NOT` write to a prefix they do not own.
+- This ADR does not enumerate reserved keys. Reserved keys live in the
+  systems that define them.
+
+### Lifetime contract
+
+- `annotations`
+  - `MUST` be persisted as part of the record's permanent representation
+    when the record is persisted.
+  - `SHOULD` be projected onto downstream resources by default. Projectors
+    `MAY` filter on a per-rule basis.
+- `transient_annotations`
+  - Are attached at write time for the lifetime of the delivery.
+  - `MUST NOT` be projected onto downstream resources by default.
+  - `MAY` be persisted alongside the record for replay and audit purposes.
+    Persistence `MAY` be opted out of per stream or per system when the
+    cost is not justified; the default is to persist.
+- Resources and projections `MUST NOT` expose a `transient_annotations`
+  field.
+
+### Choosing between the two
+
+The writer decides at attach time:
+
+- If the entry is a fact about the record that should remain true forever,
+  it belongs in `annotations`.
+- If the entry is meaningful only for this delivery or this processing
+  moment, it belongs in `transient_annotations`.
+
+This decision is local to the writer and does not require coordination with
+consumers.
+
+### Normative rules
+
+- You `MUST` place caller-attached opaque metadata in `annotations` or
+  `transient_annotations`. You `MUST NOT` introduce parallel ad-hoc fields
+  for the same purpose.
+- You `MUST` use a prefix you own, or no prefix at all. You `MUST NOT`
+  write to a prefix you do not own.
+- You `MUST` encode non-string values as strings.
+- You `MUST` choose `annotations` vs `transient_annotations` based on
+  lifetime intent, not on the topical category of the entry.
+- You `MUST NOT` move platform-interpreted concerns into annotations.
+  First-class envelope fields are governed separately.
+- Projectors `MUST NOT` copy `transient_annotations` to resources by
+  default.
+- Storage `MUST` persist `annotations` whenever the underlying record is
+  persisted.
+
+## Links
+
+* [Kubernetes: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+* [Kubernetes: Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+* [CloudEvents specification](https://github.com/cloudevents/spec)

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -1,7 +1,7 @@
 ---
 id: '5177934677'
 title: Annotations and Transient Annotations
-state: Draft
+state: Reviewing
 created: 2026-06-28
 tags: [annotations, metadata, event-sourcing, eda]
 category: Platform
@@ -29,10 +29,14 @@ Existing precedents were considered:
 
 - Kubernetes splits metadata into `labels` (selectable, indexed) and
   `annotations` (opaque, free-form). The split exists because the API server
-  is the selector engine and has to index a bounded namespace cheaply. We do
-  not have a platform-level selector engine, and we do not know our query
-  patterns up front. Adopting the `labels`/`annotations` split would be
-  ceremony without a corresponding system behavior.
+  is the selector engine and has to index a bounded namespace cheaply, and
+  because selector values need bounded, matchable syntax. The split earns
+  its keep exactly where such an engine exists. This ADR does not assume
+  one: it governs the opaque namespace. A system that does operate a
+  selector engine (resolving routing or binding selectors against
+  metadata) `MAY` add a separate selectable field for those keys as a
+  downstream decision; that field is out of this ADR's scope and does not
+  change the rules here.
 - CloudEvents, NATS headers, Kafka headers, AMQP application properties, and
   HTTP headers all use a single flat map with a reserved-prefix convention.
 - Event-sourced systems consistently distinguish between metadata that is
@@ -73,6 +77,8 @@ transient_annotations: { <key>: <string>, ... }
   equivalent open-ended JSON value maps as the platform contract. Typed
   domain data belongs in first-class fields or separately governed schemas.
 - Both fields are optional. Absence and an empty map are equivalent.
+- Caller-attached opaque metadata `MUST` live in these two fields. Records
+  `MUST NOT` grow parallel ad-hoc fields for the same purpose.
 - This specification defines no size or count limits. Systems `MAY`
   impose documented limits, and propagating consumers `MAY` filter
   entries to stay within them.
@@ -211,36 +217,19 @@ The writer decides at attach time:
 This decision is local to the writer and does not require coordination with
 consumers.
 
-### Normative rules
+## Consequences
 
-- You `MUST` place caller-attached opaque metadata in `annotations` or
-  `transient_annotations`. You `MUST NOT` introduce parallel ad-hoc fields
-  for the same purpose.
-- You `MUST` use a prefix you own, or no prefix at all. You `MUST NOT`
-  write to a prefix you do not own; propagating an existing entry
-  verbatim is not writing.
-- A prefix, once used, is a permanent identifier. You `MUST NOT` rewrite
-  persisted keys when the domain behind a prefix changes or lapses.
-- You `MUST` encode non-string values as strings.
-- You `MUST NOT` use annotations as a typed payload escape hatch. If
-  consumers need typed semantics, define a dedicated field or schema instead.
-- You `MUST` choose `annotations` vs `transient_annotations` based on
-  lifetime intent, not on the topical category of the entry.
-- You `MUST NOT` move platform-interpreted concerns into annotations.
-  First-class envelope fields are governed separately.
-- Projectors `MUST NOT` copy `transient_annotations` to resources by
-  default.
-- Consumers that emit records as a result of processing an incoming
-  record `SHOULD` propagate the incoming `transient_annotations` onto all
-  of the resulting records.
-- An operation that writes multiple records `MUST` attach the same
-  `transient_annotations` to every record it writes.
-- You `MUST NOT` rely on `annotations` propagating to resulting records;
-  each writer attaches its own.
-- You `MUST NOT` depend on a `transient_annotations` entry being present
-  for correctness.
-- Storage `MUST` persist `annotations` whenever the underlying record is
-  persisted.
+- Every record type answers "where does caller metadata go?" the same
+  way, and a reader checks exactly two fields to find it.
+- Correlating a causation chain end to end works without polluting any
+  resource's projected representation, because propagation and projection
+  have opposite defaults.
+- Prefix ownership makes cross-team key collisions a naming violation
+  rather than a runtime surprise, and lint can enforce the syntax.
+- Two doors are deliberately left open for downstream decisions: key
+  registries (enumerating well-known keys per system) and a separate
+  selectable field for systems that operate a selector engine. Neither
+  changes this spec.
 
 ## Links
 

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -107,6 +107,9 @@ Keys follow the Kubernetes label key syntax, by reference:
     `MAY` filter on a per-rule basis.
 - `transient_annotations`
   - Are attached at write time for the lifetime of the delivery.
+  - Describe the operation, not an individual record: an operation that
+    writes multiple records `MUST` attach the same entries to every
+    record it writes.
   - `MUST NOT` be projected onto downstream resources by default.
   - `MAY` be persisted alongside the record for replay and audit purposes.
     Persistence `MAY` be opted out of per stream or per system when the
@@ -130,12 +133,14 @@ The two fields have opposite defaults:
   entry forward when the fact it records is also true of the new record.
 - `transient_annotations` travel with the write path. A consumer that
   emits records as a result of processing an incoming record `SHOULD`
-  propagate the incoming `transient_annotations` onto the resulting
-  records, so that context spanning a causation chain (for example,
-  correlating the deliveries of a workflow end to end) survives every hop
-  without becoming part of any record's projected representation.
-  Consumers `MAY` filter or add entries when propagating, subject to the
-  ownership rules above.
+  propagate the incoming `transient_annotations` onto all of the records
+  the resulting operation emits, not a chosen subset, so that context
+  spanning a causation chain (for example, correlating the deliveries of
+  a workflow end to end) survives every hop without becoming part of any
+  record's projected representation. Consumers `MAY` filter or add
+  entries when propagating, subject to the ownership rules above;
+  filtering is per entry and applies uniformly across the operation's
+  resulting records.
 
 Propagation terminates where projection begins: resources never expose
 transient annotations, regardless of how many hops an entry traveled.
@@ -171,8 +176,10 @@ consumers.
 - Projectors `MUST NOT` copy `transient_annotations` to resources by
   default.
 - Consumers that emit records as a result of processing an incoming
-  record `SHOULD` propagate the incoming `transient_annotations` onto the
-  resulting records.
+  record `SHOULD` propagate the incoming `transient_annotations` onto all
+  of the resulting records.
+- An operation that writes multiple records `MUST` attach the same
+  `transient_annotations` to every record it writes.
 - You `MUST NOT` rely on `annotations` propagating to resulting records;
   each writer attaches its own.
 - Storage `MUST` persist `annotations` whenever the underlying record is

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -114,14 +114,42 @@ Keys follow the Kubernetes label key syntax, by reference:
 - Resources and projections `MUST NOT` expose a `transient_annotations`
   field.
 
+### Propagation
+
+Projection and propagation are distinct behaviors. Projection copies
+metadata from a record onto a downstream resource (a read model), and is
+governed by the lifetime contract above. Propagation copies metadata from
+an incoming record onto the new records emitted as a result of processing
+it, such as a workflow consuming an event and writing the events that
+result from it.
+
+The two fields have opposite defaults:
+
+- `annotations` describe the record they are attached to and do not
+  propagate by default. The writer of a resulting record `MAY` copy an
+  entry forward when the fact it records is also true of the new record.
+- `transient_annotations` travel with the write path. A consumer that
+  emits records as a result of processing an incoming record `SHOULD`
+  propagate the incoming `transient_annotations` onto the resulting
+  records, so that context spanning a causation chain (for example,
+  correlating the deliveries of a workflow end to end) survives every hop
+  without becoming part of any record's projected representation.
+  Consumers `MAY` filter or add entries when propagating, subject to the
+  ownership rules above.
+
+Propagation terminates where projection begins: resources never expose
+transient annotations, regardless of how many hops an entry traveled.
+
 ### Choosing between the two
 
 The writer decides at attach time:
 
 - If the entry is a fact about the record that should remain true forever,
   it belongs in `annotations`.
-- If the entry is meaningful only for this delivery or this processing
-  moment, it belongs in `transient_annotations`.
+- If the entry is meaningful only for the delivery and processing of the
+  record, it belongs in `transient_annotations`. Transient does not mean
+  single-hop: an entry can propagate across an entire processing chain
+  (see Propagation) and still never surface on a resource.
 
 This decision is local to the writer and does not require coordination with
 consumers.
@@ -142,6 +170,11 @@ consumers.
   First-class envelope fields are governed separately.
 - Projectors `MUST NOT` copy `transient_annotations` to resources by
   default.
+- Consumers that emit records as a result of processing an incoming
+  record `SHOULD` propagate the incoming `transient_annotations` onto the
+  resulting records.
+- You `MUST NOT` rely on `annotations` propagating to resulting records;
+  each writer attaches its own.
 - Storage `MUST` persist `annotations` whenever the underlying record is
   persisted.
 

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -13,7 +13,7 @@ category: Platform
 
 Records that move through our systems (events, commands, requests,
 projections, resources) need a place to carry caller-attached metadata that the
-platform itself does not interpret. Examples of the *shape* of need (not an
+platform itself does not interpret. Examples of the _shape_ of need (not an
 enumeration of keys) include: cross-cutting observability context, write-time
 plumbing, caller-owned domain tags, and platform cross-cutting concerns that
 are not first-class envelope fields.
@@ -68,6 +68,10 @@ transient_annotations: { <key>: <string>, ... }
 - Values are **opaque to the platform**. The platform does not parse,
   validate, or interpret values. Callers that need structured values
   `MUST` encode them as strings (for example, JSON-encoded).
+- Annotation values `MUST NOT` use typed dynamic containers such as
+  `map<string, google.protobuf.Value>`, `google.protobuf.Struct`, or
+  equivalent open-ended JSON value maps as the platform contract. Typed
+  domain data belongs in first-class fields or separately governed schemas.
 - Both fields are optional. Absence and an empty map are equivalent.
 
 ### Key syntax
@@ -88,8 +92,11 @@ Keys follow the Kubernetes label key syntax, by reference:
   written by the platform.
 - Keys under a platform-owned prefix are reserved for that platform.
   Consumers `MUST NOT` write to a prefix they do not own.
-- This ADR does not enumerate reserved keys. Reserved keys live in the
-  systems that define them.
+- `trogondb.com/` is reserved for TrogonDB platform-written annotations.
+  Callers `MUST NOT` write keys under this prefix unless they are acting as
+  the platform component that owns the key.
+- Additional reserved prefixes `MUST` be documented by the system that owns
+  them before they are used.
 
 ### Lifetime contract
 
@@ -127,6 +134,8 @@ consumers.
 - You `MUST` use a prefix you own, or no prefix at all. You `MUST NOT`
   write to a prefix you do not own.
 - You `MUST` encode non-string values as strings.
+- You `MUST NOT` use annotations as a typed payload escape hatch. If
+  consumers need typed semantics, define a dedicated field or schema instead.
 - You `MUST` choose `annotations` vs `transient_annotations` based on
   lifetime intent, not on the topical category of the entry.
 - You `MUST NOT` move platform-interpreted concerns into annotations.
@@ -138,6 +147,6 @@ consumers.
 
 ## Links
 
-* [Kubernetes: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
-* [Kubernetes: Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
-* [CloudEvents specification](https://github.com/cloudevents/spec)
+- [Kubernetes: Labels and Selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/)
+- [Kubernetes: Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+- [CloudEvents specification](https://github.com/cloudevents/spec)

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -58,12 +58,14 @@ platform-interpreted fields) are out of scope and are governed elsewhere.
 
 ## Resolution
 
-Records expose two sibling fields with identical shape and identical key
-rules, distinguished only by lifetime:
+Written records (events, commands, requests) expose two sibling fields
+with identical shape and identical key rules, distinguished only by
+lifetime. Resources and projections expose only the first; they never
+carry a `transient_annotations` field (see Lifetime contract):
 
 ```
 annotations:           { <key>: <string>, ... }
-transient_annotations: { <key>: <string>, ... }
+transient_annotations: { <key>: <string>, ... }   # written records only
 ```
 
 ### Shape
@@ -152,7 +154,8 @@ to.
   - Describe the operation, not an individual record: an operation that
     writes multiple records `MUST` attach the same entries to every
     record it writes.
-  - `MUST NOT` be projected onto downstream resources by default.
+  - `MUST NOT` be projected onto downstream resources. This is absolute,
+    not a default: the field does not exist on resources.
   - `MAY` be persisted alongside the record for replay and audit purposes.
     Persistence `MAY` be opted out of per stream or per system when the
     cost is not justified; the default is to persist.

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -73,6 +73,9 @@ transient_annotations: { <key>: <string>, ... }
   equivalent open-ended JSON value maps as the platform contract. Typed
   domain data belongs in first-class fields or separately governed schemas.
 - Both fields are optional. Absence and an empty map are equivalent.
+- This specification defines no size or count limits. Systems `MAY`
+  impose documented limits, and propagating consumers `MAY` filter
+  entries to stay within them.
 
 ### Key syntax
 
@@ -97,12 +100,24 @@ Keys follow the Kubernetes label key syntax, by reference:
   the platform component that owns the key.
 - Additional reserved prefixes `MUST` be documented by the system that owns
   them before they are used.
+- Ownership governs authorship: creating, modifying, or removing an
+  entry. Carrying an existing entry forward verbatim during propagation
+  is not authorship and is permitted for keys the propagator does not
+  own.
 
 ### Lifetime contract
+
+An **operation** is a single logical write performed in response to one
+processing occasion, such as handling one command, one consumed delivery,
+or one API request, regardless of how many records or streams it writes
+to.
 
 - `annotations`
   - `MUST` be persisted as part of the record's permanent representation
     when the record is persisted.
+  - Follow the mutability of the record they are attached to: immutable
+    on immutable records such as events, updatable on mutable records
+    such as resources, subject to the ownership rules above.
   - `SHOULD` be projected onto downstream resources by default. Projectors
     `MAY` filter on a per-rule basis.
 - `transient_annotations`
@@ -114,6 +129,9 @@ Keys follow the Kubernetes label key syntax, by reference:
   - `MAY` be persisted alongside the record for replay and audit purposes.
     Persistence `MAY` be opted out of per stream or per system when the
     cost is not justified; the default is to persist.
+  - Are best-effort context. Because persistence can be opted out and
+    propagation can filter, consumers `MUST NOT` depend on an entry
+    being present for correctness.
 - Resources and projections `MUST NOT` expose a `transient_annotations`
   field.
 
@@ -142,6 +160,19 @@ The two fields have opposite defaults:
   filtering is per entry and applies uniformly across the operation's
   resulting records.
 
+Key collisions during propagation resolve as follows:
+
+- When an operation processes multiple incoming records whose
+  `transient_annotations` conflict on a key, the consumer `MUST` resolve
+  the conflict deterministically. Dropping the conflicting key is the
+  safe default; a wrong value is worse than an absent one.
+- When a propagated entry collides with an entry the consumer attaches
+  itself, the consumer's own entry wins: the author of the operation
+  outranks inherited context.
+- Propagation carries unprefixed keys across writer boundaries, where
+  they can collide with another writer's unprefixed keys. Callers that
+  need collision-free keys across a chain `SHOULD` use a prefix.
+
 Propagation terminates where projection begins: resources never expose
 transient annotations, regardless of how many hops an entry traveled.
 
@@ -165,7 +196,8 @@ consumers.
   `transient_annotations`. You `MUST NOT` introduce parallel ad-hoc fields
   for the same purpose.
 - You `MUST` use a prefix you own, or no prefix at all. You `MUST NOT`
-  write to a prefix you do not own.
+  write to a prefix you do not own; propagating an existing entry
+  verbatim is not writing.
 - You `MUST` encode non-string values as strings.
 - You `MUST NOT` use annotations as a typed payload escape hatch. If
   consumers need typed semantics, define a dedicated field or schema instead.
@@ -182,6 +214,8 @@ consumers.
   `transient_annotations` to every record it writes.
 - You `MUST NOT` rely on `annotations` propagating to resulting records;
   each writer attaches its own.
+- You `MUST NOT` depend on a `transient_annotations` entry being present
+  for correctness.
 - Storage `MUST` persist `annotations` whenever the underlying record is
   persisted.
 

--- a/src/adrs/5177934677/README.md
+++ b/src/adrs/5177934677/README.md
@@ -105,6 +105,27 @@ Keys follow the Kubernetes label key syntax, by reference:
   is not authorship and is permitted for keys the propagator does not
   own.
 
+### Prefix identity and stability
+
+A prefix is an opaque identifier that borrows DNS syntax for
+decentralized uniqueness. It is not a live pointer to a DNS record:
+
+- A prefix does not need to resolve. Ownership is established when the
+  prefix is first documented, per the reservation rules above, not by
+  holding the DNS registration.
+- Teams do not need their own domain. Ownership delegates the way DNS
+  does: a team `MAY` mint a prefix under a domain its organization owns
+  (for example, `payments.example.com/`).
+- Once a key under a prefix has been written, the prefix is permanent.
+  Renaming, losing, or selling the domain later does not transfer or
+  invalidate the prefix, and registering a lapsed domain grants no claim
+  over keys already documented by another writer.
+- Because persisted records are immutable, writers `SHOULD` mint
+  prefixes on the most stable name available, such as a product or
+  system name rather than corporate branding. Migrating to a new prefix
+  means writing new keys going forward; keys under the old prefix remain
+  valid in persisted records forever and `MUST NOT` be rewritten.
+
 ### Lifetime contract
 
 An **operation** is a single logical write performed in response to one
@@ -198,6 +219,8 @@ consumers.
 - You `MUST` use a prefix you own, or no prefix at all. You `MUST NOT`
   write to a prefix you do not own; propagating an existing entry
   verbatim is not writing.
+- A prefix, once used, is a permanent identifier. You `MUST NOT` rewrite
+  persisted keys when the domain behind a prefix changes or lapses.
 - You `MUST` encode non-string values as strings.
 - You `MUST NOT` use annotations as a typed payload escape hatch. If
   consumers need typed semantics, define a dedicated field or schema instead.


### PR DESCRIPTION
Adds ADR [`5177934677`](https://github.com/straw-hat-team/adr/blob/yordis/docs-annotations-adr/src/adrs/5177934677/README.md) (`src/adrs/5177934677/README.md`): "Annotations and Transient Annotations".

- Records carry caller-attached opaque metadata in many places (events, commands, projections), and without a shared contract every system invents its own naming, ownership, and lifetime conventions.
- Existing precedents (Kubernetes labels/annotations, CloudEvents extensions, NATS/Kafka/HTTP headers) do not match our environment cleanly: we have no platform-level selector engine, so a selectability-based split would be ceremony without a corresponding system behavior.
- The axis that maps to real, irreversible system behavior in our environment is lifetime (persisted and projectable vs write-time only), and that decision is local to the writer and does not require downstream coordination.
- The dominant use case for transient annotations is correlating a workflow's causation chain end to end, which the persist/project contract alone could not express: without explicit propagation semantics, "lifetime of the delivery" could be read as dying at the first hop, and implementers would diverge.
- Projection and propagation get opposite defaults because they answer different questions: annotations state facts about the record they sit on, while transient annotations carry context about the operation that produced it, so the former project without propagating and the latter propagate without projecting.
- Transient annotations are scoped to the operation rather than the individual record because correlation only works if every record an operation emits carries the same context; annotating a subset would silently break the chain.
- Edge cases (ownership vs propagation, key collisions, presence guarantees, mutability, limits) are resolved explicitly so independent implementers converge without coordinating.
- Scoping the ADR to the spec only (no enumerated keys, no placement guidance) keeps the contract stable while leaving room for registries and downstream ADRs to evolve independently.