### PR TITLE
docs(adr): resource placement via untyped recursive containers

### DIFF
--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -53,7 +53,7 @@ pointer changes); there is no authoritative structure to validate against, so a
 typo silently mints a phantom branch and restructures leave no audit
 trail; and policy bound to a prefix detaches silently on rename. The
 chosen design keeps the pointer an opaque string and moves the structure
-into events.
+into audited tree operations.
 
 **Multiple placements per resource.** Rejected: placement exists to answer
 which policy chain governs a resource and where name resolution starts;
@@ -116,7 +116,7 @@ Nothing is stored inside one; resources point at it. The rules:
 6. Queries ("what is in this place?") are read-model projections over
    resource pointers. Membership is relation tuples in the authorization
    system, not tree data.
-7. Moves are human-only tree events. Inherited stances are positional and
+7. Moves are human-only tree operations. Inherited stances are positional and
    re-evaluate from the new position; ids are stable, so references never
    break. Tree invariants (parent exists, no cycles, depth cap of 10) are
    enforced by the tree's command handler at the point of change.

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -113,9 +113,9 @@ Nothing is stored inside one; resources point at it. The rules:
 5. **Policy flows down.** A stance attached to a place governs its whole
    subtree: permissions and grants inherit additively; budgets and limits
    inherit as ceilings.
-6. Queries ("what is in this place?") are read-model projections over
-   resource pointers. Membership is relation tuples in the authorization
-   system, not tree data.
+6. Queries ("what is in this place?") are computed from resource
+   pointers; the tree stores no contents. Membership (who stands where)
+   lives in the authorization system, not in the tree.
 7. Moves are human-only tree operations. Inherited stances are positional and
    re-evaluate from the new position; ids are stable, so references never
    break. Tree invariants (parent exists, no cycles, depth cap of 10) are

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -86,28 +86,38 @@ survived at scale across three independent cloud vendors, it removes every
 platform guess about tenant org charts, and it keeps the platform's
 interpretation surface minimal and provable.
 
-The model, reduced to what the mechanism actually needs:
+The model, reduced to what the mechanism actually needs: **there is no
+container entity at all**. A container is an id that appears in its
+tenant's hierarchy, and the hierarchy is the entity:
 
 ```
-Container { id, parentId? }
+Hierarchy (one per tenant, event-sourced):
+  NodeAdded   { nodeId, parentId }
+  NodeMoved   { nodeId, fromParent, toParent }
+  NodeRemoved { nodeId }
 ```
 
-A node and its parent. Everything else is derivable, decorative, or a
-surface concern:
+The current tree is a projection of those events. This placement of the
+parent relationship follows from the commands themselves: adding or moving
+a node validates tree invariants (parent exists, no cycle, depth cap), so
+the tree is the unit of consistency, not the node. Nodes carry no fields;
+a `parentId` is event data, not a node property.
 
-- The tenant is the root ancestor. The wall is the node with no parent;
-  implementations may denormalize a tenant column for query efficiency,
-  but it is not model.
+Everything else is derivable, decorative, or a surface concern:
+
+- The tenant is the tree; the wall needs no field anywhere.
 - `kind` (`project`, `team`, `user-home`) is an entry in the standard
-  labels map that every entity already carries. A value the platform never
-  interprets does not deserve a schema field.
+  labels map, attached to the node id like labels on any entity. A value
+  the platform never interprets does not deserve schema.
 - A human-readable name or slug (unique among siblings) belongs to the
-  API-surface layer that renders path-style resource names, not to the
-  core model.
+  API-surface layer that renders path-style resource names. Exposing a
+  parent pointer on read models (as GCP folders and Kubernetes HNC do) is
+  a projection choice, not model.
 - Every resource carries a single `container` reference (one canonical
-  parent, its placement) plus a separate `owner` principal (its
+  node id, its placement) plus a separate `owner` principal (its
   accountability). Neither is derivable from the other.
-- Depth is capped at single digits, matching industry practice.
+- Depth is capped at single digits, matching industry practice, enforced
+  as a tree invariant at the point of change.
 
 The platform interprets the tree through exactly two operations:
 

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -47,9 +47,9 @@ remain the right substrate for membership.
 **Structure encoded in the string (paths or prefixes).** Placement as a
 path such as `acme/backend/ml`: walk-up is segment-stripping, flow-down is
 prefix matching, and no tree needs to exist. Rejected: a rename or move
-invalidates every pointer (impossible to repair under immutable events;
-with opaque ids one `NodeMoved` event rearranges everything and no pointer
-changes); there is no authoritative structure to validate against, so a
+invalidates every pointer (unrepairable wherever history is immutable;
+with opaque ids a single recorded move rearranges everything and no
+pointer changes); there is no authoritative structure to validate against, so a
 typo silently mints a phantom branch and restructures leave no audit
 trail; and policy bound to a prefix detaches silently on rename. The
 chosen design keeps the pointer an opaque string and moves the structure
@@ -91,17 +91,19 @@ opposite moods, and a design needs both.
 
 ## Resolution
 
-Chosen option: one event-sourced hierarchy of untyped places per tenant,
-because it is the only pattern that survived at scale across three
-independent cloud vendors, and it removes every platform guess about
-tenant org charts.
+Chosen option: one hierarchy of untyped places per tenant, because it is
+the only pattern that survived at scale across three independent cloud
+vendors, and it removes every platform guess about tenant org charts.
 
 **A container is a named place in the tenant's tree, not a thing.**
 Nothing is stored inside one; resources point at it. The rules:
 
 1. Each tenant has one tree. Its nodes ("containers") are opaque ids.
-   The tree is an event stream (`NodeAdded`, `NodeMoved`, `NodeRemoved`);
-   the current tree is a projection. There is no container record.
+   The tree changes only through three audited operations (add, move,
+   remove), each validated against the whole tree; the current tree is
+   derived from that history. There is no container record. How the
+   history is stored (event stream, audited table) is an implementation
+   choice per service.
 2. Every resource carries exactly one `container` id (placement) and one
    `owner` principal (accountability). Neither derives from the other.
 3. `kind` and display names are labels and API-surface slugs on the node

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -1,0 +1,144 @@
+---
+id: '4761776210'
+title: Resource placement via untyped recursive containers
+state: Draft
+created: 2026-07-09
+tags: [multi-tenancy, hierarchy, authorization, platform-design]
+category: Platform
+---
+
+# Resource placement via untyped recursive containers
+
+## Context
+
+Platforms that host resources on behalf of organizations (agents, schedules,
+skills, policies, ...) must answer "where does this resource live?" before
+they can answer who sees it, who may use it, and which rules apply to it.
+
+The tempting first answer is to enumerate the organizational levels the
+platform expects — `org | project | user`, or `org | team | user` — and put
+that enum on every resource. This fails on contact with real tenants: one
+company organizes by teams inside departments, another by client accounts,
+another by environments, and a solo operator has no structure at all. Any
+enum we pick encodes *our* guess about *their* org chart, and every mismatch
+becomes either a schema migration or a workaround.
+
+Two adjacent concerns get conflated with placement and must be separated
+first, because they answer different questions:
+
+| Concern | Question | Nature |
+| --- | --- | --- |
+| Tenant | which isolation wall is this inside? | the hard boundary; nothing crosses it |
+| Placement | where does it live within the tenant? | structural: visibility, routing, name resolution |
+| Ownership | which human answers for it? | accountability: a principal, not a place |
+
+Ownership must not be derived from placement: a tenant-wide resource still
+needs exactly one accountable human (escalations need an addressee), and a
+resource placed in one group may be maintained by someone outside it.
+
+### What the industry converged on
+
+All three major clouds faced unknown tenant structure and independently
+built the same architecture:
+
+| Platform | Wall | Generic recursive middle | Promoted leaf (interpreted) | Rules flow down as |
+| --- | --- | --- | --- | --- |
+| Google Cloud | Organization | **Folders** (untyped; "departments, teams, applications, environments — your choice") | **Project** (billing, quotas, APIs) | IAM policy (additive) |
+| AWS | Organization root | **Organizational Units** (untyped, recursive) | **Account** (billing, isolation) | SCPs (ceilings/filters) |
+| Azure | Tenant root | **Management Groups** (untyped, recursive) | **Subscription** (billing) | Azure Policy + RBAC |
+
+Three properties recur:
+
+1. **The middle of the hierarchy is untyped and recursive.** None of them
+   ship a "team" or "department" concept; customers model themselves.
+   Depth is capped at single digits everywhere.
+2. **Exactly one container kind is promoted** — the level where billing and
+   isolation anchor (Project / Account / Subscription). Fully generic
+   hierarchies do not exist in production; fully enumerated ones don't
+   either.
+3. **Policy attaches to nodes and inherits downward**, never as fields on
+   the resources themselves.
+
+Two boundary cases complete the picture. Kubernetes shipped *flat*
+namespaces plus labels, and hierarchy had to be bolted on afterward (the
+Hierarchical Namespace Controller) — the cautionary tale for skipping the
+tree. Zanzibar (Google's authorization system, ancestor of SpiceDB) is the
+opposite extreme: no fixed hierarchy at all, only relations
+(`parent-of`, `member-of`), with authorization resolved over whatever graph
+the tenant builds — which is what sits underneath membership resolution in
+any of these designs.
+
+### The inheritance-semantics fork
+
+The clouds disagree on one thing, and the disagreement is a real design
+input rather than noise: GCP IAM inheritance is **additive-only** (a child
+can gain access from its ancestors, never lose it), while AWS SCPs are
+**ceilings** (an ancestor can bound what everything below may do). These
+are not interchangeable: permissions and limits inherit in opposite moods.
+
+## Resolution
+
+Chosen option: **one untyped recursive `Container` entity, with the tenant
+as the single promoted anchor**, because it is the only pattern that
+survived at scale (three independent cloud vendors), it removes every
+platform guess about tenant org charts, and it keeps the platform's
+interpretation surface minimal and provable.
+
+The model:
+
+```
+Container { id, tenant, parentId?, kind, name }
+```
+
+- Every tenant has a root container. Tenants build arbitrary trees under
+  it. Depth is capped (single digits, matching industry practice).
+- Every resource carries a single `container` reference — one canonical
+  parent (placement), plus a separate `owner` principal (accountability).
+  Neither is derivable from the other.
+- **`kind` is a label, not a schema.** `"project"`, `"team"`,
+  `"user-home"` are display vocabulary. The platform has no code path
+  conditioned on `kind`.
+
+The platform interprets the tree through exactly two operations:
+
+1. **Walk up (resolution).** Resolving a resource by name from a container
+   searches that container, then its ancestors toward the root; the
+   nearest match wins. This generalizes "user copy shadows project copy
+   shadows org template" without naming any of those levels.
+2. **Flow down (policy).** Stances attached to a container (access
+   bindings, budgets, evaluation rules) apply to its entire subtree — with
+   the inheritance mood split by stance type:
+   - **additive** for permissions/grants (GCP IAM mood): descendants gain,
+     never lose;
+   - **ceiling** for budgets/limits (AWS SCP mood): ancestors bound
+     descendants.
+
+Promotion rule (the escape hatch): if the platform ever must genuinely
+*interpret* a kind — e.g. billing rolls up per "project" — that one kind is
+promoted to a real concept at that time. Promotion is cheap; demotion is a
+breaking change. The tenant anchor is the only promotion made up front,
+matching the one promotion all three clouds made.
+
+What this rejects:
+
+- **Enumerated scope levels** (`org | project | user` as an enum on
+  resources): encodes our guess of their org chart; every mismatch is a
+  migration.
+- **Flat + labels only** (Kubernetes mood): no native shadowing or
+  policy inheritance; hierarchy gets reinvented badly on top.
+- **Pure relations with no canonical parent** (raw Zanzibar): maximally
+  flexible, but resources lose a single unambiguous home, and name
+  resolution ("which `pr-reviewer` do I get here?") has no defined answer.
+  Relations remain the substrate for *membership*; placement stays a
+  single canonical parent.
+
+## Links
+
+- [Google Cloud resource hierarchy (Folders)](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
+- [AWS Organizations — Organizational Units](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html)
+- [Azure management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview)
+- [Zanzibar: Google's Consistent, Global Authorization System](https://research.google/pubs/pub48190/)
+- [Kubernetes Hierarchical Namespace Controller](https://github.com/kubernetes-sigs/hierarchical-namespaces)
+- [Google AIP-122: Resource names](https://google.aip.dev/122) / [AIP-124: Resource association](https://google.aip.dev/124)
+- Internal: agent-platform design record Q10/Q21/Q22 (operator research
+  vault, `agent-definition/service-design-qa.md`)

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -96,33 +96,43 @@ the only pattern that survived at scale across three independent cloud
 vendors, and it removes every platform guess about tenant org charts.
 
 **A container is a named place in the tenant's tree, not a thing.**
-Nothing is stored inside one; resources point at it. The rules:
+Nothing is stored inside one; resources point at it.
 
-1. Each tenant has one tree. Its nodes ("containers") are opaque ids.
-   The tree changes only through three audited operations (add, move,
-   remove), each validated against the whole tree; the current tree is
-   derived from that history. There is no container record. How the
-   history is stored (event stream, audited table) is an implementation
-   choice per service.
-2. Every resource carries exactly one `container` id (placement) and one
-   `owner` principal (accountability). Neither derives from the other.
-3. `kind` and display names are labels and API-surface slugs on the node
-   id. The platform has no code path conditioned on them.
-4. **Resolution walks up.** Finding a resource by name searches the
-   starting place, then its ancestors; nearest match wins.
-5. **Policy flows down.** A stance attached to a place governs its whole
-   subtree: permissions and grants inherit additively; budgets and limits
-   inherit as ceilings.
-6. Queries ("what is in this place?") are computed from resource
-   pointers; the tree stores no contents. Membership (who stands where)
-   lives in the authorization system, not in the tree.
-7. Moves are human-only tree operations. Inherited stances are positional and
-   re-evaluate from the new position; ids are stable, so references never
-   break. Tree invariants (parent exists, no cycles, depth cap of 10) are
-   enforced by the tree's command handler at the point of change.
-8. The tenant is the only promoted concept. Any other kind gets promoted
-   only when the platform must genuinely interpret it (promotion is
-   cheap; demotion is breaking).
+The decision, five rules:
+
+1. Each tenant has one tree of places. A place is an opaque id. The tree
+   changes only through three audited operations (add, move, remove),
+   each validated against the whole tree (parent exists, no cycles, depth
+   cap of 10). There is no container record; the current tree is derived
+   from the history of those operations.
+2. Every resource carries exactly one `container` id (where it lives) and
+   one `owner` principal (which human answers for it). Neither derives
+   from the other.
+3. The platform never interprets what a place *means*. Words like
+   "project" or "team" are labels on the id; display names are
+   API-surface slugs. No code path is conditioned on them.
+4. **Finding walks up.** Looking up a resource by name searches the
+   starting place, then its ancestors toward the root; the nearest match
+   wins.
+5. **Rules flow down.** A policy attached to a place governs everything
+   at or below it. Permissions accumulate downward (a child can gain,
+   never lose); limits bound downward (a parent caps everything below).
+
+## Consequences
+
+- "What is in this place?" is a query over resource pointers; the tree
+  itself stores nothing.
+- Who belongs to a place (membership) is authorization data, kept in the
+  authorization system, not in the tree.
+- Moving a place is one audited operation; ids never change, so nothing
+  that references a place breaks. Policies apply from the new position
+  going forward.
+- If the platform ever needs to treat one kind of place specially (for
+  example, billing per "project"), that kind is promoted to a real
+  concept at that moment, by a new decision. Until then, everything stays
+  a label.
+- How each service stores the tree history (event stream, audited table)
+  is that service's implementation choice.
 
 ## Links
 

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -86,9 +86,18 @@ survived at scale across three independent cloud vendors, it removes every
 platform guess about tenant org charts, and it keeps the platform's
 interpretation surface minimal and provable.
 
-The model, reduced to what the mechanism actually needs: **there is no
-container entity at all**. A container is an id that appears in its
-tenant's hierarchy, and the hierarchy is the entity:
+**Definition, first: a container is a named place in the tenant's tree,
+not a thing.** Resources point at a place (`container: "cont_backend"`),
+policies attach to a place, people stand at a place through membership.
+Nothing is ever stored "inside" one: containment is by reference, and
+"what is in this container?" is a query over resources that point at it,
+the same way a tag works. The word is kept because the industry calls
+these folders, OUs, and management groups; the mechanics are a tag with a
+tree.
+
+Given that, the model reduces to what the mechanism actually needs:
+**there is no container entity at all**. A container is an id that
+appears in its tenant's hierarchy, and the hierarchy is the entity:
 
 ```
 Hierarchy (one per tenant, event-sourced):

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -44,6 +44,25 @@ Rejected for placement: resources lose a single unambiguous home, and
 "which `pr-reviewer` do I get here?" has no defined answer. Relations
 remain the right substrate for membership.
 
+**Structure encoded in the string (paths or prefixes).** Placement as a
+path such as `acme/backend/ml`: walk-up is segment-stripping, flow-down is
+prefix matching, and no tree needs to exist. Rejected: a rename or move
+invalidates every pointer (impossible to repair under immutable events;
+with opaque ids one `NodeMoved` event rearranges everything and no pointer
+changes); there is no authoritative structure to validate against, so a
+typo silently mints a phantom branch and restructures leave no audit
+trail; and policy bound to a prefix detaches silently on rename. The
+chosen design keeps the pointer an opaque string and moves the structure
+into events.
+
+**Multiple placements per resource.** Rejected: placement exists to answer
+which policy chain governs a resource and where name resolution starts;
+two parents give two ceilings and two shadowing orders with no defined
+winner. All three clouds are single-parent for the same reason (AIP-124:
+at most one canonical parent). The need to appear in several groupings is
+served by labels (unlimited), and cross-place access by shares; one
+placement for governance, many labels for queries.
+
 **A container entity with fields.** Two drafts died under review:
 `{ id, tenant, parentId?, kind, name }` (tenant is derivable, kind is an
 uninterpreted label, name is an API-surface slug) and then

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -11,196 +11,97 @@ category: Platform
 
 ## Context
 
-Platforms that host resources on behalf of organizations (agents,
-schedules, skills, policies) must answer "where does this resource live?"
-before they can answer who sees it, who may use it, and which rules apply
-to it.
+Platforms that host resources for organizations (agents, schedules,
+skills, policies) must answer "where does this resource live?" before they
+can answer who sees it, who may use it, and which rules apply to it.
 
-The tempting first answer is to enumerate the organizational levels the
-platform expects, such as `org | project | user`, and put that enum on
-every resource. This fails on contact with real tenants. One company
-organizes by teams inside departments, another by client accounts, another
-by environments, and a solo operator has no structure at all. Any enum we
-pick encodes our guess about their org chart, and every mismatch becomes
-either a schema migration or a workaround.
+Three concerns get conflated and must stay separate:
 
-Two adjacent concerns get conflated with placement and must be separated
-first, because they answer different questions:
+| Concern | Question |
+| --- | --- |
+| Tenant | Which isolation wall is this inside? |
+| Placement | Where does it live within the tenant? |
+| Ownership | Which human answers for it? |
 
-| Concern | Question | Nature |
-| --- | --- | --- |
-| Tenant | Which isolation wall is this inside? | The hard boundary; nothing crosses it. |
-| Placement | Where does it live within the tenant? | Structural: visibility, routing, name resolution. |
-| Ownership | Which human answers for it? | Accountability: a principal, not a place. |
+Ownership is never derived from placement: a tenant-wide resource still
+needs exactly one accountable human.
 
-Ownership must not be derived from placement. A tenant-wide resource still
-needs exactly one accountable human, because escalations need an
-addressee. A resource placed in one group may be maintained by someone
-outside it.
+### Considered options
+
+**Enumerated levels.** An enum such as `org | project | user` on every
+resource. Rejected: it encodes our guess about the tenant's org chart.
+One company organizes by teams inside departments, another by client
+accounts, another is a solo operator. Every mismatch becomes a schema
+migration or a workaround.
+
+**Flat namespaces plus labels** (the Kubernetes shape). Rejected: no
+native shadowing or policy inheritance, so hierarchy gets reinvented
+badly on top. Kubernetes itself needed the Hierarchical Namespace
+Controller bolted on later.
+
+**Pure relations, no canonical parent** (the raw Zanzibar shape).
+Rejected for placement: resources lose a single unambiguous home, and
+"which `pr-reviewer` do I get here?" has no defined answer. Relations
+remain the right substrate for membership.
+
+**A container entity with fields.** Two drafts died under review:
+`{ id, tenant, parentId?, kind, name }` (tenant is derivable, kind is an
+uninterpreted label, name is an API-surface slug) and then
+`{ id, parentId? }` (the parent is not a node property: commands that
+change the tree validate tree-wide invariants, so the tree is the
+consistency unit, not the node).
 
 ### What the industry converged on
 
 All three major clouds faced unknown tenant structure and independently
-built the same architecture:
+built the same shape:
 
-| Platform | Wall | Generic recursive middle | Promoted leaf (interpreted) | Rules flow down as |
+| Platform | Wall | Untyped recursive middle | Promoted leaf | Rules flow down as |
 | --- | --- | --- | --- | --- |
-| Google Cloud | Organization | Folders (untyped; "departments, teams, applications, environments") | Project (billing, quotas, APIs) | IAM policy (additive) |
-| AWS | Organization root | Organizational Units (untyped, recursive) | Account (billing, isolation) | SCPs (ceilings/filters) |
-| Azure | Tenant root | Management Groups (untyped, recursive) | Subscription (billing) | Azure Policy + RBAC |
+| Google Cloud | Organization | Folders | Project (billing, quotas) | IAM policy (additive) |
+| AWS | Organization root | Organizational Units | Account (billing, isolation) | SCPs (ceilings) |
+| Azure | Tenant root | Management Groups | Subscription (billing) | Azure Policy + RBAC |
 
-Three properties recur:
-
-1. The middle of the hierarchy is untyped and recursive. None of them ship
-   a "team" or "department" concept; customers model themselves. Every
-   vendor imposes a small fixed nesting limit rather than unbounded depth.
-2. Exactly one container kind is promoted: the level where billing and
-   isolation anchor (Project, Account, Subscription). Fully generic
-   hierarchies do not exist in production, and fully enumerated ones do
-   not either.
-3. Policy attaches to nodes and inherits downward, never as fields on the
-   resources themselves.
-
-Two boundary cases complete the picture. Kubernetes shipped flat
-namespaces plus labels, and hierarchy had to be bolted on afterward via
-the Hierarchical Namespace Controller; that is the cautionary tale for
-skipping the tree. Zanzibar (Google's authorization system, ancestor of
-SpiceDB) is the opposite extreme: no fixed hierarchy at all, only
-relations such as `parent-of` and `member-of`, with authorization resolved
-over whatever graph the tenant builds. Relations of that kind sit
-underneath membership resolution in any of these designs.
-
-### The inheritance-semantics fork
-
-The clouds disagree on one thing, and the disagreement is a real design
-input rather than noise. GCP IAM inheritance is additive-only: a child can
-gain access from its ancestors, never lose it. AWS SCPs are ceilings: an
-ancestor can bound what everything below may do. These are not
-interchangeable. Permissions and limits inherit in opposite moods.
+Recurring properties: the middle is untyped and recursive (customers
+model themselves), exactly one container kind is promoted (where billing
+and isolation anchor), policy attaches to nodes and inherits downward,
+and every vendor caps nesting depth. The clouds disagree on inheritance
+mood: GCP IAM is additive-only (children gain, never lose), AWS SCPs are
+ceilings (ancestors bound children). Permissions and limits inherit in
+opposite moods, and a design needs both.
 
 ## Resolution
 
-Chosen option: one untyped recursive `Container` entity, with the tenant
-as the single promoted anchor, because it is the only pattern that
-survived at scale across three independent cloud vendors, it removes every
-platform guess about tenant org charts, and it keeps the platform's
-interpretation surface minimal and provable.
+Chosen option: one event-sourced hierarchy of untyped places per tenant,
+because it is the only pattern that survived at scale across three
+independent cloud vendors, and it removes every platform guess about
+tenant org charts.
 
-**Definition, first: a container is a named place in the tenant's tree,
-not a thing.** Resources point at a place (`container: "cont_backend"`),
-policies attach to a place, people stand at a place through membership.
-Nothing is ever stored "inside" one: containment is by reference, and
-"what is in this container?" is a query over resources that point at it,
-the same way a tag works. The word is kept because the industry calls
-these folders, OUs, and management groups; the mechanics are a tag with a
-tree.
+**A container is a named place in the tenant's tree, not a thing.**
+Nothing is stored inside one; resources point at it. The rules:
 
-Given that, the model reduces to what the mechanism actually needs:
-**there is no container entity at all**. A container is an id that
-appears in its tenant's hierarchy, and the hierarchy is the entity:
-
-```
-Hierarchy (one per tenant, event-sourced):
-  NodeAdded   { nodeId, parentId }
-  NodeMoved   { nodeId, fromParent, toParent }
-  NodeRemoved { nodeId }
-```
-
-The current tree is a projection of those events. This placement of the
-parent relationship follows from the commands themselves: adding or moving
-a node validates tree invariants (parent exists, no cycle, depth cap), so
-the tree is the unit of consistency, not the node. Nodes carry no fields;
-a `parentId` is event data, not a node property.
-
-Everything else is derivable, decorative, or a surface concern:
-
-- The tenant is the tree; the wall needs no field anywhere.
-- `kind` (`project`, `team`, `user-home`) is an entry in the standard
-  labels map, attached to the node id like labels on any entity. A value
-  the platform never interprets does not deserve schema.
-- A human-readable name or slug (unique among siblings) belongs to the
-  API-surface layer that renders path-style resource names. Exposing a
-  parent pointer on read models (as GCP folders and Kubernetes HNC do) is
-  a projection choice, not model.
-- Every resource carries a single `container` reference (one canonical
-  node id, its placement) plus a separate `owner` principal (its
-  accountability). Neither is derivable from the other.
-- Depth is capped at a fixed limit of 10 levels, enforced as a tree
-  invariant at the point of change. The number is deliberately deeper than
-  any observed tenant need while keeping walk-up bounded; changing it
-  later only relaxes or tightens a validation, never the model.
-
-The platform interprets the tree through exactly two operations:
-
-1. **Walk up (resolution).** Resolving a resource by name from a container
-   searches that container, then its ancestors toward the root; the
-   nearest match wins. This generalizes "user copy shadows project copy
-   shadows org template" without naming any of those levels.
-2. **Flow down (policy).** Stances attached to a container (access
-   bindings, budgets, evaluation rules) apply to its entire subtree, with
-   the inheritance mood split by stance type:
-   - additive for permissions and grants (the GCP IAM mood): descendants
-     gain, never lose;
-   - ceiling for budgets and limits (the AWS SCP mood): ancestors bound
-     descendants.
-
-Three clarifications complete the semantics:
-
-- **Queries are projections, not a third operation.** Listing or selecting
-  resources across a subtree (for example, routing work to any agent
-  matching a label under a given node) is a read-model query that may
-  traverse the projected tree in either direction. The two operations
-  above are the only *semantic* interpretations the platform defines;
-  everything else reads the projection.
-- **Membership is not hierarchy data.** Principals relate to node ids
-  through relation tuples (`member-of`) held by the authorization system,
-  in the Zanzibar style. The hierarchy stream owns structure only.
-  Effective visibility composes the two: membership says where you stand;
-  walk up says what you can reach from there.
-- **Moves are rare, human-only, and take effect prospectively.**
-  `NodeMoved` revalidates tree invariants and repositions the whole
-  subtree; inherited stances (grants, ceilings) are positional, so they
-  re-evaluate from the new position at their next evaluation. This is
-  consistent with the platform rule that definitions pin while
-  authorization never pins: nothing that referenced a node id breaks,
-  because ids are stable and only the arrangement changed.
-
-Promotion rule, the escape hatch: if the platform ever must genuinely
-interpret a kind (for example, billing rolls up per "project"), that one
-kind is promoted to a real concept at that time. Promotion is cheap;
-demotion is a breaking change. The tenant anchor is the only promotion
-made up front, matching the one promotion all three clouds made.
-
-### How the model shrank (decision journey)
-
-The recorded drafts, each rejected on challenge, are part of this
-decision:
-
-1. `Container { id, tenant, parentId?, kind, name }`. Rejected: `tenant`
-   is derivable (the root ancestor), `kind` is an uninterpreted label
-   (belongs in the labels map), `name` is an API-surface slug.
-2. `Container { id, parentId? }`. Rejected: the parent relationship is not
-   a node property. The commands that change the tree validate tree-wide
-   invariants (parent exists, no cycle, depth), so the tree is the
-   consistency unit and the event stream; a node owns nothing.
-3. Final: no container entity. A container is an opaque id whose meaning
-   accrues from the planes that mention it: hierarchy events arrange it,
-   labels decorate it, policy bindings select it, resources reference it.
-   Validity of an id is checked where it is used, against the hierarchy
-   projection, never inside consumers.
-
-What this rejects:
-
-- Enumerated scope levels (`org | project | user` as an enum on
-  resources): encodes our guess of their org chart; every mismatch is a
-  migration.
-- Flat plus labels only (the Kubernetes mood): no native shadowing or
-  policy inheritance, so hierarchy gets reinvented badly on top.
-- Pure relations with no canonical parent (raw Zanzibar): maximally
-  flexible, but resources lose a single unambiguous home, and name
-  resolution ("which `pr-reviewer` do I get here?") has no defined answer.
-  Relations remain the substrate for membership; placement stays a single
-  canonical parent.
+1. Each tenant has one tree. Its nodes ("containers") are opaque ids.
+   The tree is an event stream (`NodeAdded`, `NodeMoved`, `NodeRemoved`);
+   the current tree is a projection. There is no container record.
+2. Every resource carries exactly one `container` id (placement) and one
+   `owner` principal (accountability). Neither derives from the other.
+3. `kind` and display names are labels and API-surface slugs on the node
+   id. The platform has no code path conditioned on them.
+4. **Resolution walks up.** Finding a resource by name searches the
+   starting place, then its ancestors; nearest match wins.
+5. **Policy flows down.** A stance attached to a place governs its whole
+   subtree: permissions and grants inherit additively; budgets and limits
+   inherit as ceilings.
+6. Queries ("what is in this place?") are read-model projections over
+   resource pointers. Membership is relation tuples in the authorization
+   system, not tree data.
+7. Moves are human-only tree events. Inherited stances are positional and
+   re-evaluate from the new position; ids are stable, so references never
+   break. Tree invariants (parent exists, no cycles, depth cap of 10) are
+   enforced by the tree's command handler at the point of change.
+8. The tenant is the only promoted concept. Any other kind gets promoted
+   only when the platform must genuinely interpret it (promotion is
+   cheap; demotion is breaking).
 
 ## Links
 

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -86,20 +86,28 @@ survived at scale across three independent cloud vendors, it removes every
 platform guess about tenant org charts, and it keeps the platform's
 interpretation surface minimal and provable.
 
-The model:
+The model, reduced to what the mechanism actually needs:
 
 ```
-Container { id, tenant, parentId?, kind, name }
+Container { id, parentId? }
 ```
 
-- Every tenant has a root container. Tenants build arbitrary trees under
-  it. Depth is capped at single digits, matching industry practice.
+A node and its parent. Everything else is derivable, decorative, or a
+surface concern:
+
+- The tenant is the root ancestor. The wall is the node with no parent;
+  implementations may denormalize a tenant column for query efficiency,
+  but it is not model.
+- `kind` (`project`, `team`, `user-home`) is an entry in the standard
+  labels map that every entity already carries. A value the platform never
+  interprets does not deserve a schema field.
+- A human-readable name or slug (unique among siblings) belongs to the
+  API-surface layer that renders path-style resource names, not to the
+  core model.
 - Every resource carries a single `container` reference (one canonical
   parent, its placement) plus a separate `owner` principal (its
   accountability). Neither is derivable from the other.
-- `kind` is a label, not a schema. Values like `project`, `team`, and
-  `user-home` are display vocabulary. The platform has no code path
-  conditioned on `kind`.
+- Depth is capped at single digits, matching industry practice.
 
 The platform interprets the tree through exactly two operations:
 

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -11,30 +11,32 @@ category: Platform
 
 ## Context
 
-Platforms that host resources on behalf of organizations (agents, schedules,
-skills, policies, ...) must answer "where does this resource live?" before
-they can answer who sees it, who may use it, and which rules apply to it.
+Platforms that host resources on behalf of organizations (agents,
+schedules, skills, policies) must answer "where does this resource live?"
+before they can answer who sees it, who may use it, and which rules apply
+to it.
 
 The tempting first answer is to enumerate the organizational levels the
-platform expects — `org | project | user`, or `org | team | user` — and put
-that enum on every resource. This fails on contact with real tenants: one
-company organizes by teams inside departments, another by client accounts,
-another by environments, and a solo operator has no structure at all. Any
-enum we pick encodes *our* guess about *their* org chart, and every mismatch
-becomes either a schema migration or a workaround.
+platform expects, such as `org | project | user`, and put that enum on
+every resource. This fails on contact with real tenants. One company
+organizes by teams inside departments, another by client accounts, another
+by environments, and a solo operator has no structure at all. Any enum we
+pick encodes our guess about their org chart, and every mismatch becomes
+either a schema migration or a workaround.
 
 Two adjacent concerns get conflated with placement and must be separated
 first, because they answer different questions:
 
 | Concern | Question | Nature |
 | --- | --- | --- |
-| Tenant | which isolation wall is this inside? | the hard boundary; nothing crosses it |
-| Placement | where does it live within the tenant? | structural: visibility, routing, name resolution |
-| Ownership | which human answers for it? | accountability: a principal, not a place |
+| Tenant | Which isolation wall is this inside? | The hard boundary; nothing crosses it. |
+| Placement | Where does it live within the tenant? | Structural: visibility, routing, name resolution. |
+| Ownership | Which human answers for it? | Accountability: a principal, not a place. |
 
-Ownership must not be derived from placement: a tenant-wide resource still
-needs exactly one accountable human (escalations need an addressee), and a
-resource placed in one group may be maintained by someone outside it.
+Ownership must not be derived from placement. A tenant-wide resource still
+needs exactly one accountable human, because escalations need an
+addressee. A resource placed in one group may be maintained by someone
+outside it.
 
 ### What the industry converged on
 
@@ -43,44 +45,44 @@ built the same architecture:
 
 | Platform | Wall | Generic recursive middle | Promoted leaf (interpreted) | Rules flow down as |
 | --- | --- | --- | --- | --- |
-| Google Cloud | Organization | **Folders** (untyped; "departments, teams, applications, environments — your choice") | **Project** (billing, quotas, APIs) | IAM policy (additive) |
-| AWS | Organization root | **Organizational Units** (untyped, recursive) | **Account** (billing, isolation) | SCPs (ceilings/filters) |
-| Azure | Tenant root | **Management Groups** (untyped, recursive) | **Subscription** (billing) | Azure Policy + RBAC |
+| Google Cloud | Organization | Folders (untyped; "departments, teams, applications, environments") | Project (billing, quotas, APIs) | IAM policy (additive) |
+| AWS | Organization root | Organizational Units (untyped, recursive) | Account (billing, isolation) | SCPs (ceilings/filters) |
+| Azure | Tenant root | Management Groups (untyped, recursive) | Subscription (billing) | Azure Policy + RBAC |
 
 Three properties recur:
 
-1. **The middle of the hierarchy is untyped and recursive.** None of them
-   ship a "team" or "department" concept; customers model themselves.
-   Depth is capped at single digits everywhere.
-2. **Exactly one container kind is promoted** — the level where billing and
-   isolation anchor (Project / Account / Subscription). Fully generic
-   hierarchies do not exist in production; fully enumerated ones don't
-   either.
-3. **Policy attaches to nodes and inherits downward**, never as fields on
-   the resources themselves.
+1. The middle of the hierarchy is untyped and recursive. None of them ship
+   a "team" or "department" concept; customers model themselves. Depth is
+   capped at single digits everywhere.
+2. Exactly one container kind is promoted: the level where billing and
+   isolation anchor (Project, Account, Subscription). Fully generic
+   hierarchies do not exist in production, and fully enumerated ones do
+   not either.
+3. Policy attaches to nodes and inherits downward, never as fields on the
+   resources themselves.
 
-Two boundary cases complete the picture. Kubernetes shipped *flat*
-namespaces plus labels, and hierarchy had to be bolted on afterward (the
-Hierarchical Namespace Controller) — the cautionary tale for skipping the
-tree. Zanzibar (Google's authorization system, ancestor of SpiceDB) is the
-opposite extreme: no fixed hierarchy at all, only relations
-(`parent-of`, `member-of`), with authorization resolved over whatever graph
-the tenant builds — which is what sits underneath membership resolution in
-any of these designs.
+Two boundary cases complete the picture. Kubernetes shipped flat
+namespaces plus labels, and hierarchy had to be bolted on afterward via
+the Hierarchical Namespace Controller; that is the cautionary tale for
+skipping the tree. Zanzibar (Google's authorization system, ancestor of
+SpiceDB) is the opposite extreme: no fixed hierarchy at all, only
+relations such as `parent-of` and `member-of`, with authorization resolved
+over whatever graph the tenant builds. Relations of that kind sit
+underneath membership resolution in any of these designs.
 
 ### The inheritance-semantics fork
 
 The clouds disagree on one thing, and the disagreement is a real design
-input rather than noise: GCP IAM inheritance is **additive-only** (a child
-can gain access from its ancestors, never lose it), while AWS SCPs are
-**ceilings** (an ancestor can bound what everything below may do). These
-are not interchangeable: permissions and limits inherit in opposite moods.
+input rather than noise. GCP IAM inheritance is additive-only: a child can
+gain access from its ancestors, never lose it. AWS SCPs are ceilings: an
+ancestor can bound what everything below may do. These are not
+interchangeable. Permissions and limits inherit in opposite moods.
 
 ## Resolution
 
-Chosen option: **one untyped recursive `Container` entity, with the tenant
-as the single promoted anchor**, because it is the only pattern that
-survived at scale (three independent cloud vendors), it removes every
+Chosen option: one untyped recursive `Container` entity, with the tenant
+as the single promoted anchor, because it is the only pattern that
+survived at scale across three independent cloud vendors, it removes every
 platform guess about tenant org charts, and it keeps the platform's
 interpretation surface minimal and provable.
 
@@ -91,12 +93,12 @@ Container { id, tenant, parentId?, kind, name }
 ```
 
 - Every tenant has a root container. Tenants build arbitrary trees under
-  it. Depth is capped (single digits, matching industry practice).
-- Every resource carries a single `container` reference — one canonical
-  parent (placement), plus a separate `owner` principal (accountability).
-  Neither is derivable from the other.
-- **`kind` is a label, not a schema.** `"project"`, `"team"`,
-  `"user-home"` are display vocabulary. The platform has no code path
+  it. Depth is capped at single digits, matching industry practice.
+- Every resource carries a single `container` reference (one canonical
+  parent, its placement) plus a separate `owner` principal (its
+  accountability). Neither is derivable from the other.
+- `kind` is a label, not a schema. Values like `project`, `team`, and
+  `user-home` are display vocabulary. The platform has no code path
   conditioned on `kind`.
 
 The platform interprets the tree through exactly two operations:
@@ -106,39 +108,37 @@ The platform interprets the tree through exactly two operations:
    nearest match wins. This generalizes "user copy shadows project copy
    shadows org template" without naming any of those levels.
 2. **Flow down (policy).** Stances attached to a container (access
-   bindings, budgets, evaluation rules) apply to its entire subtree — with
+   bindings, budgets, evaluation rules) apply to its entire subtree, with
    the inheritance mood split by stance type:
-   - **additive** for permissions/grants (GCP IAM mood): descendants gain,
-     never lose;
-   - **ceiling** for budgets/limits (AWS SCP mood): ancestors bound
+   - additive for permissions and grants (the GCP IAM mood): descendants
+     gain, never lose;
+   - ceiling for budgets and limits (the AWS SCP mood): ancestors bound
      descendants.
 
-Promotion rule (the escape hatch): if the platform ever must genuinely
-*interpret* a kind — e.g. billing rolls up per "project" — that one kind is
-promoted to a real concept at that time. Promotion is cheap; demotion is a
-breaking change. The tenant anchor is the only promotion made up front,
-matching the one promotion all three clouds made.
+Promotion rule, the escape hatch: if the platform ever must genuinely
+interpret a kind (for example, billing rolls up per "project"), that one
+kind is promoted to a real concept at that time. Promotion is cheap;
+demotion is a breaking change. The tenant anchor is the only promotion
+made up front, matching the one promotion all three clouds made.
 
 What this rejects:
 
-- **Enumerated scope levels** (`org | project | user` as an enum on
+- Enumerated scope levels (`org | project | user` as an enum on
   resources): encodes our guess of their org chart; every mismatch is a
   migration.
-- **Flat + labels only** (Kubernetes mood): no native shadowing or
-  policy inheritance; hierarchy gets reinvented badly on top.
-- **Pure relations with no canonical parent** (raw Zanzibar): maximally
+- Flat plus labels only (the Kubernetes mood): no native shadowing or
+  policy inheritance, so hierarchy gets reinvented badly on top.
+- Pure relations with no canonical parent (raw Zanzibar): maximally
   flexible, but resources lose a single unambiguous home, and name
   resolution ("which `pr-reviewer` do I get here?") has no defined answer.
-  Relations remain the substrate for *membership*; placement stays a
-  single canonical parent.
+  Relations remain the substrate for membership; placement stays a single
+  canonical parent.
 
 ## Links
 
 - [Google Cloud resource hierarchy (Folders)](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy)
-- [AWS Organizations — Organizational Units](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html)
+- [AWS Organizations: Organizational Units](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_ous.html)
 - [Azure management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview)
 - [Zanzibar: Google's Consistent, Global Authorization System](https://research.google/pubs/pub48190/)
 - [Kubernetes Hierarchical Namespace Controller](https://github.com/kubernetes-sigs/hierarchical-namespaces)
 - [Google AIP-122: Resource names](https://google.aip.dev/122) / [AIP-124: Resource association](https://google.aip.dev/124)
-- Internal: agent-platform design record Q10/Q21/Q22 (operator research
-  vault, `agent-definition/service-design-qa.md`)

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -1,7 +1,7 @@
 ---
 id: '4761776210'
 title: Resource placement via untyped recursive containers
-state: Draft
+state: Reviewing
 created: 2026-07-09
 tags: [multi-tenancy, hierarchy, authorization, platform-design]
 category: Platform
@@ -52,8 +52,8 @@ built the same architecture:
 Three properties recur:
 
 1. The middle of the hierarchy is untyped and recursive. None of them ship
-   a "team" or "department" concept; customers model themselves. Depth is
-   capped at single digits everywhere.
+   a "team" or "department" concept; customers model themselves. Every
+   vendor imposes a small fixed nesting limit rather than unbounded depth.
 2. Exactly one container kind is promoted: the level where billing and
    isolation anchor (Project, Account, Subscription). Fully generic
    hierarchies do not exist in production, and fully enumerated ones do
@@ -116,8 +116,10 @@ Everything else is derivable, decorative, or a surface concern:
 - Every resource carries a single `container` reference (one canonical
   node id, its placement) plus a separate `owner` principal (its
   accountability). Neither is derivable from the other.
-- Depth is capped at single digits, matching industry practice, enforced
-  as a tree invariant at the point of change.
+- Depth is capped at a fixed limit of 10 levels, enforced as a tree
+  invariant at the point of change. The number is deliberately deeper than
+  any observed tenant need while keeping walk-up bounded; changing it
+  later only relaxes or tightens a validation, never the model.
 
 The platform interprets the tree through exactly two operations:
 
@@ -133,11 +135,50 @@ The platform interprets the tree through exactly two operations:
    - ceiling for budgets and limits (the AWS SCP mood): ancestors bound
      descendants.
 
+Three clarifications complete the semantics:
+
+- **Queries are projections, not a third operation.** Listing or selecting
+  resources across a subtree (for example, routing work to any agent
+  matching a label under a given node) is a read-model query that may
+  traverse the projected tree in either direction. The two operations
+  above are the only *semantic* interpretations the platform defines;
+  everything else reads the projection.
+- **Membership is not hierarchy data.** Principals relate to node ids
+  through relation tuples (`member-of`) held by the authorization system,
+  in the Zanzibar style. The hierarchy stream owns structure only.
+  Effective visibility composes the two: membership says where you stand;
+  walk up says what you can reach from there.
+- **Moves are rare, human-only, and take effect prospectively.**
+  `NodeMoved` revalidates tree invariants and repositions the whole
+  subtree; inherited stances (grants, ceilings) are positional, so they
+  re-evaluate from the new position at their next evaluation. This is
+  consistent with the platform rule that definitions pin while
+  authorization never pins: nothing that referenced a node id breaks,
+  because ids are stable and only the arrangement changed.
+
 Promotion rule, the escape hatch: if the platform ever must genuinely
 interpret a kind (for example, billing rolls up per "project"), that one
 kind is promoted to a real concept at that time. Promotion is cheap;
 demotion is a breaking change. The tenant anchor is the only promotion
 made up front, matching the one promotion all three clouds made.
+
+### How the model shrank (decision journey)
+
+The recorded drafts, each rejected on challenge, are part of this
+decision:
+
+1. `Container { id, tenant, parentId?, kind, name }`. Rejected: `tenant`
+   is derivable (the root ancestor), `kind` is an uninterpreted label
+   (belongs in the labels map), `name` is an API-surface slug.
+2. `Container { id, parentId? }`. Rejected: the parent relationship is not
+   a node property. The commands that change the tree validate tree-wide
+   invariants (parent exists, no cycle, depth), so the tree is the
+   consistency unit and the event stream; a node owns nothing.
+3. Final: no container entity. A container is an opaque id whose meaning
+   accrues from the planes that mention it: hierarchy events arrange it,
+   labels decorate it, policy bindings select it, resources reference it.
+   Validity of an id is checked where it is used, against the hierarchy
+   projection, never inside consumers.
 
 What this rejects:
 

--- a/src/adrs/4761776210/README.md
+++ b/src/adrs/4761776210/README.md
@@ -1,7 +1,7 @@
 ---
 id: '4761776210'
 title: Resource placement via untyped recursive containers
-state: Reviewing
+state: Approved
 created: 2026-07-09
 tags: [multi-tenancy, hierarchy, authorization, platform-design]
 category: Platform


### PR DESCRIPTION
- Platforms we are designing (agent platform first) must place resources inside tenant org structures we cannot predict; enumerating levels like org/project/user encodes our guess of the tenant's org chart, and every mismatch becomes a migration.
- All three major clouds independently converged on the same answer (untyped recursive containers, one promoted anchor, policy inheriting down), so recording it as an ADR prevents re-litigating placement per service.
- The inheritance-mood split (additive for permissions, ceilings for limits) is a fork the clouds disagree on; deciding it now prevents it becoming an implicit bug later.
- Rejected alternatives (enumerated levels, flat-plus-labels, pure relations, path-encoded placement, multiple placements, container entities with fields) are recorded so future services do not re-explore dead ends.