### PR TITLE
[ADR] Actor and Authority Taxonomy for Managed Systems

### DIFF
--- a/src/adrs/0289186035/README.md
+++ b/src/adrs/0289186035/README.md
@@ -1,7 +1,7 @@
 ---
 id: '0289186035'
 title: Built-In Resources and Their Modes
-state: Reviewing
+state: Approved
 created: 2026-08-03
 tags: [naming, taxonomy, schema, built-in, defaults, lifecycle]
 category: Platform

--- a/src/adrs/0289186035/README.md
+++ b/src/adrs/0289186035/README.md
@@ -1,0 +1,117 @@
+---
+id: '0289186035'
+title: Built-In Resources and Their Modes
+state: Reviewing
+created: 2026-08-03
+tags: [naming, taxonomy, schema, built-in, defaults, lifecycle]
+category: Platform
+---
+
+# Built-In Resources and Their Modes
+
+## Context
+
+[ADR#8779742261](../8779742261/README.md) establishes the actor ladder and
+the mutation-authority field for rows converged from deployment
+configuration. A sibling concept keeps appearing next to it and is easy to
+conflate with it: resources defined by the **software release itself**.
+Default roles, reserved permissions, sentinel rows, standard policies,
+template objects: present in every installation, identical everywhere, and
+changed only by upgrading the software.
+
+Built-in and system-managed share a surface symptom (the API refuses some
+or all mutations) but differ in every property that matters:
+
+| | Built-in | System-managed |
+| --- | --- | --- |
+| Defined by | the release (code, migrations) | this deployment's configuration |
+| Varies per installation | no | yes |
+| Changes when | the software upgrades | the operator changes configuration |
+| Example | a reserved `admin` role, a sentinel platform row | a config-declared operator service account |
+
+Conflating them produces wrong designs in both directions: treating a
+built-in as system-managed invites operators to "configure" something the
+release owns; treating a system-managed row as built-in hides it from the
+deployment's declared state. And "built-in" alone is underspecified: the
+industry applies built-in-ness in several distinct modes, from fully
+immutable to merely seeded, so declaring a resource built-in without
+declaring its mode leaves the enforcement undefined.
+
+## Resolution
+
+Chosen option: "built-in is the release's authority, documented per
+resource as one of six modes", because the verified industry survey shows
+built-in-ness is not one behavior but a spectrum, and every ambiguity
+encountered came from leaving the mode implicit.
+
+### Definition and place in the taxonomy
+
+A **built-in resource** is one whose defining authority is the software
+release: its shape and existence ship with the code, and its legitimate
+mutation vehicle is an upgrade. In the actor ladder, the release acts
+through the `system` rung's machinery (migrations, boot reconciliation),
+but the authority is distinct from deployment configuration: a
+`managed_by`-style field, where built-ins are rows at all, marks them with
+their own value (`builtin`) rather than overloading `system`.
+
+### The six modes (verified precedents, 2026-08-03)
+
+| Mode | Behavior | Verified precedents |
+| --- | --- | --- |
+| 1. Immutable | Exists in every installation; nothing about it can change through any surface | PostgreSQL `template0` ("should never be changed after the database cluster has been initialized", "normally marked `datallowconn = false` to prevent its modification"); GCP predefined roles (fixed `ETag AA==`); Azure Policy `policyType: Static`; AWS managed policies ("You cannot change the permissions defined in AWS managed policies"); Grafana fixed roles ("called 'fixed' because you cannot change or delete fixed roles") |
+| 2. Editable-except-core | The row is built-in and undeletable, most properties open, specific properties locked | Okta default policies ("Default policies are required, and you can't delete them"; "Default policies always have one default rule that you can't delete... always the last rule in the priority order"); the claim that specific default-rule sub-properties are locked is plausible but UNVERIFIED against a primary source |
+| 3. Reconciled-on-boot | Edits are allowed but the platform converges built-ins back to the release's definition on restart, with an explicit per-object opt-out | Kubernetes default RBAC: "The API server reconciles default ClusterRole and ClusterRoleBinding objects on every restart"; opt-out via the `rbac.authorization.k8s.io/autoupdate` annotation set to `false`; "Many of these are `system:` prefixed, which indicates that the resource is directly managed by the cluster control plane"; "Modifications to default `system:` ClusterRoles... are overwritten when the API server restarts" |
+| 4. Delete-protected-but-configurable | Cannot be deleted, freely reconfigurable, never reconciled back | Grafana basic roles ("You can use RBAC to modify the permissions associated with any basic role"; "You can't delete basic roles"); WorkOS default environment role (undeletable while it holds default status; reassign first) |
+| 5. Seeded-but-unprotected | The release provides defaults copied at creation time; the copies are wholly owned by their owner afterward | GitHub default labels ("anyone with write access to the repository can edit or delete the labels in that repository later. Adding, editing, or deleting a default label does not add, edit, or delete the label from existing repositories"); PostgreSQL `template1` ("If you add objects to `template1`, these objects will be copied into subsequently created user databases") |
+| 6. Code-constant | The built-in is not data at all: it lives in code and never materializes as a row | Reserved role/permission keys defined in source; Clerk's `org:sys_*` permission key convention |
+
+### Selection guidance
+
+1. **Prefer mode 6 (code constant) whenever the built-in has no
+   per-installation state.** A row that never varies is a liability: it
+   must be seeded, protected, and migrated. Reserved role keys and
+   capability sets belong in code.
+2. **Use mode 1 (immutable row) when relational integrity needs an anchor
+   row**: foreign keys, audit chains, or sentinel addressing. Pair the row
+   with database-level protection (a type/kind column plus delete and
+   immutability triggers), since a sentinel protected only by code
+   discipline is not protected.
+3. **Use mode 3 (reconciled) when built-ins must be operator-tunable yet
+   upgrade-refreshable**, and make the opt-out explicit and per-object,
+   as Kubernetes does with `autoupdate`; silent reconciliation over
+   operator edits is the K8s-documented footgun ("modifications... are
+   overwritten when the API server restarts").
+4. **Use mode 5 (seeded) when the default is a starting point, not a
+   contract**: after copying, the rows are ordinary user data and take
+   the normal authority value, not `builtin`.
+5. **Declare the mode in the resource's documentation and, for modes 1
+   through 4, enforce it in the API**, following the mutation-authority
+   ADR's enforcement rule: the marker must be checked and rejected at the
+   write path, not merely displayed.
+6. **Never let "default" imply "protected"**: GitHub's default labels and
+   Okta's default rules show the industry uses "default" for both
+   protected and unprotected things; the mode, not the adjective, defines
+   the behavior.
+
+### Relation to the mutation-authority field
+
+Where built-in resources are rows and coexist with system-managed and
+API-managed rows on the same table, they take a distinct `managed_by`
+value (`builtin`), because their authority (the release) is neither the
+deployment configuration nor any principal. Where the built-in is
+enforced through a dedicated type column instead (a sentinel row on a
+table that otherwise has no authority field), that column plus triggers
+is the equivalent mechanism, and adding a redundant authority field is
+unnecessary. Mode 5 rows are not built-in after copying and take ordinary
+authority values.
+
+## Links
+
+- [ADR#8779742261: Actor and Authority Taxonomy](../8779742261/README.md)
+- [Kubernetes default roles and auto-reconciliation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [PostgreSQL template databases](https://www.postgresql.org/docs/current/manage-ag-templatedbs.html)
+- [Grafana RBAC: basic and fixed roles](https://grafana.com/docs/grafana/latest/administration/roles-and-permissions/access-control/)
+- [Okta policy concepts (default policies)](https://developer.okta.com/docs/concepts/policies/)
+- [GitHub default labels](https://docs.github.com/en/organizations/managing-organization-settings/managing-default-labels-for-repositories-in-your-organization)
+- [GCP predefined roles](https://docs.cloud.google.com/iam/docs/roles-overview)
+- [Azure Policy `policyType`](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-basics)

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -1,7 +1,7 @@
 ---
 id: '8779742261'
 title: Actor and Authority Taxonomy for Managed Systems
-state: Reviewing
+state: Approved
 created: 2026-08-03
 tags: [naming, taxonomy, schema, authorization, gitops, identity]
 category: Platform
@@ -99,10 +99,10 @@ a channel name, where "how" is the axis being named.
 
 ### Naming rules derived from the taxonomy
 
-1. Name fields for the axis they check: an authority field names actors
-   (or the actor-channel shorthand below), a transport field names
-   channels, a scope field names boundaries. Never mix axes in one enum
-   without noticing you are doing it.
+1. Name fields for the axis they check: an authority field names actors,
+   a transport field names channels, a scope field names boundaries.
+   Never mix axes in one enum; an enum headed by an actor value takes
+   actor values throughout.
 2. A value must be true for every row in its class. Corollary: a class
    that is the union of several ladder rungs cannot be named after any
    single rung; it must be named by what the union shares.
@@ -125,29 +125,30 @@ taxonomy dictates its value structure:
 - The other class is the union of rungs 2, 3, and 4 (platform, tenant,
   and user principals all mutate through the same governed surface). By
   rule 2 it cannot be called `platform`, `customer`, or `user`; the only
-  honest names are what the union shares: **`api`** (the channel every
-  member acts through, per the single-management-surface rule) or
-  **`principal`** (the actor category every member belongs to). Industry
-  precedent exists only for the channel word (Grafana Alerting's
-  `provenance` enum uses the literal value `api` for this class; Okta
-  marks the converged class with `system`); `principal` is the
-  grammatically agent-shaped alternative with no precedent.
+  honest names are what the union shares. The chosen value is
+  **`principal`**: the actor category every member belongs to, and the
+  taxonomy's own reserved word for exactly this union, so the enum reads
+  directly off the ladder (`system | principal`, later joined by
+  `external`) and stays on one axis end to end. `principal` is the
+  official umbrella actor term at all three major clouds (AWS glossary,
+  Azure "security principal", GCP's explicit members-to-principals
+  rename).
+- The rejected runner-up was **`api`**, the channel every member acts
+  through. It carries the only exact-position precedent (Grafana
+  Alerting's `provenance` enum uses the literal value `api` for this
+  class), but that precedent does not transplant: Grafana's enum is
+  channel-consistent (`none | api | file`, all channels), whereas this
+  enum is actor-headed (`system`) and its known future value (`external`)
+  is also an actor, so importing `api` would mix axes in exactly the way
+  rule 1 of this ADR forbids. Repeated reader confusion ("managed by
+  api reads as transport, not authority") was the empirical symptom of
+  that axis mix.
 - Future authorities join as values, per rule 3: directory-synced rows
   arrive as `managed_by: external` (or a finer-grained `scim`), not as a
   stretched reading of an existing value.
 - Enforcement keys off the field at every layer: API writes rejected on
   `system` rows, converge logic writes them freely, database triggers
   make `managed_by` immutable and `system` rows undeletable.
-
-Open point while this ADR is in review: the api-side value, `api`
-(channel word, precedented by Grafana's literal `provenance: api` value)
-versus `principal` (actor word). The taxonomy proves these are the only
-two candidates. The cloud deep survey (below) shifted the evidence:
-`principal` is the official umbrella actor term at all three major clouds
-(AWS glossary, Azure "security principal", GCP's explicit
-members-to-principals rename), so it is no longer unprecedented as
-vocabulary, only as an enum value in a managed-by field. `api` retains
-the only exact-position precedent.
 
 ### Precedent survey (2026-08-03)
 

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -150,6 +150,57 @@ taxonomy dictates its value structure:
   `system` rows, converge logic writes them freely, database triggers
   make `managed_by` immutable and `system` rows undeletable.
 
+### Value shape: bare tokens versus structured identifiers
+
+A closed authority enum takes **bare tokens** (`system`, `principal`),
+never path- or URI-shaped values (`/system`, `system://...`). GCP's
+identifier grammar, the richest in the survey, exists to solve two
+problems a closed enum does not have, and GCP itself goes bare the moment
+those problems disappear:
+
+1. **Typed prefixes disambiguate type in an open field.** The IAM policy
+   binding field carries an open set of identities of different kinds, so
+   each value declares its type: `user:alice@example.com`,
+   `serviceAccount:sa@project.iam.gserviceaccount.com`. The prefix exists
+   because the set is open and heterogeneous.
+2. **URI schemes address instances and classes in federated pools:**
+   `principal://iam.googleapis.com/.../workloadIdentityPools/POOL/subject/S`
+   names one external identity, `principalSet://.../group/G` names a
+   matching class. Structure exists to *address* things.
+3. **Resource names address instances across services** (AIP-122): the
+   full resource name is "a schemeless URI with the owning API's service
+   name, followed by the relative resource name":
+   `//library.googleapis.com/publishers/123/books/les-miserables`, with
+   components alternating collection identifiers and resource IDs.
+   Structure again exists to address an open set.
+4. **And the counter-case that proves the rule:** inside that same
+   prefixed, URI-bearing binding field, GCP's closed specials are bare
+   literals: `allUsers` and `allAuthenticatedUsers` carry no prefix and
+   no scheme, because a closed reserved value has no type ambiguity to
+   resolve and nothing to address.
+
+An authority enum is case 4 everywhere: a closed set, CHECK-constrained,
+compared byte-for-byte by database triggers and pattern matches. Every
+authority enum in the survey is bare (`AWS`, `CUSTOMER`, `Local`,
+`BuiltIn`, `Custom`, `Static`, `MANAGED`, `SELF_MANAGED`,
+`EnvironmentRole`, `SystemAssigned`); no surveyed product uses a
+path-shaped enum value.
+
+The corollary for **instance attribution**: when an authority class later
+needs to say *which* manager (which sync connection, which managing
+resource), the precedented shape is a companion reference field, never a
+composite enum value. Azure keeps `type: BuiltInRole` (closed enum)
+separate from `managedBy` (a resource ID); AWS keeps Config's
+`Source.Owner` (closed enum) separate from Secrets Manager's
+`OwningService` (service identifier). So a future synced row is
+`managed_by: external` plus a `managing_connection_id` reference, not
+`managed_by: external:scim:conn_123`. If such a reference must address
+resources across services, AIP-122 full resource names are the
+precedented value format for the *reference field*, which is exactly
+where structured identifiers belong. (Reserved lexical prefixes like
+`goog-` labels and `aws:` tags are a third mechanism again: namespacing
+inside user-writable open fields, irrelevant to closed enums.)
+
 ### Precedent survey (2026-08-03)
 
 | Product | Field | Values | Behavior |
@@ -304,6 +355,7 @@ never as a bare `system` enum token.
 - [GCP IAM overview (members renamed to principals)](https://docs.cloud.google.com/iam/docs/overview)
 - [GCP service agents](https://docs.cloud.google.com/iam/docs/service-agents)
 - [GKE Autopilot managed-namespace enforcement](https://docs.cloud.google.com/kubernetes-engine/security/autopilot-cluster-policies-standard)
+- [GCP resource names (AIP-122)](https://google.aip.dev/122)
 - [Okta policy API (`system` attribute)](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/policy/)
 - [Grafana alerting provisioning (`provenance`)](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/)
 - [AWS KMS `KeyManager`](https://docs.aws.amazon.com/kms/latest/APIReference/API_KeyMetadata.html)

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -1,0 +1,157 @@
+---
+id: '8779742261'
+title: Naming the Mutation-Authority Field on System-Converged Resources
+state: Reviewing
+created: 2026-08-03
+tags: [naming, schema, authorization, gitops, identity]
+category: Platform
+---
+
+# Naming the Mutation-Authority Field on System-Converged Resources
+
+## Context
+
+A recurring design in our systems: some rows of a resource table are
+converged by the server itself from declared deployment configuration (for
+example, a GitOps operator service account and its API keys, created and
+kept in sync on every boot), while the rest are created and mutated by API
+callers. The converged rows must be read-only through the API: their single
+source of truth is the declaration, and every rule that touches them asks
+exactly one question:
+
+> **Which authority is allowed to mutate this row?**
+
+The field answering that question needs a name and values. A first attempt
+shipped as `origin` with values `config | api` and did not survive contact:
+in an identity product, `origin` is saturated vocabulary for the
+scheme-host-port web concept (CORS, WebAuthn, trusted origins), and
+`config` names where a row came from rather than anything the system ever
+checks. The renaming journey (`origin`, `declaration`, `deployment_config`,
+`provenance`, `managed_by`) showed the decision deserves a record: what
+criteria must the name satisfy, and why each candidate lives or dies.
+
+### Decision criteria
+
+1. **Name the intent, not a mechanism, not history, not a derived
+   property.** The intent is the standing mutation authority. This rules
+   out provenance-flavored names (history), mechanism names that go stale
+   when the declaration transport changes (env-declared hashes today,
+   declared public keys or federation trust later), and derived-property
+   names like `read_only` or `immutable` (the row is mutable, just not by
+   the API; "immutable for whom" is exactly the ambiguity to avoid).
+2. **Every value must be true for every row in its class.** The
+   API-governed class contains rows created by humans, by service
+   accounts, and by infrastructure-as-code controllers; any value naming a
+   specific actor is false for part of the class.
+3. **Enum, not boolean.** A third authority is plausible (SCIM- or
+   directory-synced users, federation-provisioned principals); an enum
+   absorbs it as a new value, a boolean forces a breaking reshape.
+4. **Survive authority transfer.** Adoption is a bread-and-butter GitOps
+   move (`terraform import`, Crossplane observe-and-adopt): a row created
+   through the API comes under configuration management later. A field
+   named for history cannot record that honestly; a field named for
+   authority can.
+5. **No collisions with the schema's loaded vocabulary.** In an identity
+   product this reserves `origin` (web origin), `owner`/`owned_by` (which
+   principal a credential belongs to), `client` (OAuth), `user` (the users
+   table), `tenant`, and `operator` (both the converged service account
+   itself and the human running the deployment).
+
+### Precedent survey (2026-08-03)
+
+| Product | Field | Values | Behavior |
+| --- | --- | --- | --- |
+| Okta (policies, network zones) | `system` | boolean | system rows undeletable; "created by a system or by a user" |
+| Grafana Alerting | `provenance` | `none`, `api`, `file` | file-provisioned rows locked from the API surface; escape via `X-Disable-Provenance` header |
+| Grafana dashboards | `meta.provisioned` | boolean | provisioned dashboards read-only in UI |
+| AWS KMS | `KeyManager` | `AWS`, `CUSTOMER` | AWS-managed keys not editable |
+| AWS IAM | `Scope` | `AWS`, `Local` | AWS-managed policies copy-to-edit only |
+| Azure RBAC | `type` | `BuiltInRole`, `CustomRole` | built-ins read-only |
+| Azure managed identity | `identity.type` | `SystemAssigned`, `UserAssigned` | agent-pair naming of the same boundary |
+| GCP | none | none | Google-managed vs customer-managed expressed structurally (field presence) and by naming conventions, no enum |
+| Kubernetes | `app.kubernetes.io/managed-by` | free-form label | convention only, unenforced |
+| Salesforce | `custom` | boolean | standard vs custom objects |
+| WorkOS (roles) | `type` | `EnvironmentRole`, `OrganizationRole` | row-level system-vs-custom enum; default environment role undeletable while default |
+| WorkOS (directory sync) | none | none | structurally read-only: no mutation endpoints exist; writes flow only from the source directory |
+| Clerk | none (presence of enterprise-connection record) | connection `provider`/`protocol` | directory-synced attributes documented read-only; system permissions marked only by a key-prefix convention |
+| Zitadel | none | none | runtime config declares config-only API principals (self-signed JWT against a declared public key) but marks nothing in the data model; bootstrap-created rows indistinguishable afterward |
+| Keycloak | none | none | built-ins protected by convention only |
+
+Two shapes dominate: a boolean `system` flag (Okta, Salesforce, Grafana
+dashboards) and a two-value ownership enum (AWS, Azure, Grafana Alerting,
+WorkOS roles). The cloud providers name agent pairs (`AWS | CUSTOMER`,
+system-assigned vs user-assigned), which works because a cloud provider
+and its customer really are two parties; self-hosted software has no such
+split, because the installing organization writes the deployment
+configuration and calls the API. Keycloak's nothing-at-all is the failure
+mode the field exists to avoid; Kubernetes' free-form label is the wrong
+shape for a closed two-class rule; the adjacent identity products (Clerk,
+WorkOS, Zitadel) validate the concept everywhere while fragmenting the
+shape (behavioral locks, missing endpoints, config-time auth with no data
+marking), so a single inspectable, trigger-enforceable column is more
+general than any surveyed implementation.
+
+## Resolution
+
+Chosen option: **`managed_by`, an enum with values `system | api`**,
+because it is the only candidate that satisfies every criterion: it names
+the standing authority rather than a mechanism or history (criterion 1),
+its values are true for every row in their class (criterion 2), the enum
+absorbs future authorities such as `scim` or `federation` (criterion 3),
+authority transfer on adoption is an honest update rather than a rewritten
+history (criterion 4), and neither word collides with the schema's loaded
+vocabulary (criterion 5).
+
+- **`system`** names the authority that converges declared rows: the
+  server acting on its own trust root, whatever the declaration mechanism
+  is. Okta marks exactly this class with `system`.
+- **`api`** names the only thing true of every row in the other class: it
+  is governed through the management API's capability model, by whichever
+  principal holds capability. It is a channel word rather than an agent
+  word, a deliberate asymmetry: the class has no single agent (criterion
+  2). It leans on the platform rule that the management API is the single
+  management surface with no backdoors (every management client, console,
+  CLI applier, or IaC provider, is a client of that surface), so there is
+  no third write path for the value to be wrong about. Grafana Alerting
+  uses the literal value `api` for the same class.
+- Enforcement follows the field at every layer: the API rejects writes on
+  `system` rows, the converge logic writes them freely, and database
+  triggers make `managed_by` immutable and `system` rows undeletable, so
+  ownership can be neither promoted nor laundered.
+
+Rejected alternatives:
+
+| Candidate | Kills it |
+| --- | --- |
+| `origin: config \| api` | `origin` collides with web-origin vocabulary; `config` names provenance, not authority (criteria 1, 5) |
+| `source`, `provenance` | Name history, not the standing rule; break on adoption (criterion 4): a hand-created row brought under configuration management keeps its provenance but changes its authority. Grafana's own escape header shows `provenance` behaving as misnamed authority. `provenance` is also vocabulary audit and supply-chain features (SLSA) want with its literal meaning |
+| `declaration`, `deployment_config` as the system-side value | Name today's mechanism; go stale when the declaration transport changes (criterion 1) |
+| `operator` as the system-side value | Self-referential: the operator service account is the row being managed, and rows the operator creates through the API belong to the other class (criterion 5) |
+| boolean `system` flag | Cannot grow a third authority without a breaking reshape (criterion 3) |
+| `platform \| customer` (the cloud-provider agent pair) | Right split read as roles (infrastructure-operator hat vs product-user hat), unusable words: `platform` reads as the product's platform/management plane, so rows platform admins create via the API would carry the opposite value; `customer` means tenant organizations in a multi-tenant identity product (criteria 2, 5) |
+| `user`, `customer`, `manual`, `client` as the api-side value | Each is false for part of the class (IaC-created rows are not `user`/`manual`; platform-scoped rows are not `customer`) or collides (`client` = OAuth client, `user` = users table) (criteria 2, 5) |
+| `management_api` as the api-side value | Semantically identical to `api`, strictly more verbose; acceptable fallback if the bare `api` proves confusing in practice |
+| `principal` as the api-side value | The one coherent agent word ("managed by a principal through the management surface"); grammatically reads like a dangling reference to a specific principal, and has no precedent anywhere surveyed; kept as the named alternative if `api` proves confusing in practice |
+| `owned_by` / `owner` as the column | Credential ownership already means something else on the same tables; a second ownership recreates the `origin` problem (criterion 5) |
+
+On reserving `managed_by` for a future domain concept: considered and
+rejected as a reason to pick a different name. Business-level ownership
+axes already have names (credential owner, team placement), a
+"managed by organization X" feature would want a reference column rather
+than a closed enum, and surveyed identity products name that concept
+differently anyway (Entra `onPremisesSyncEnabled`/`creationType`, Okta
+`credentials.provider`). If a synced-user feature lands later, it is the
+same mutation-authority concept and joins this field as a new value
+(`scim`, `federation`) rather than colliding with it.
+
+## Links
+
+- [Okta policy API (`system` attribute)](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/policy/)
+- [Grafana alerting provisioning (`provenance`)](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/)
+- [AWS KMS `KeyManager`](https://docs.aws.amazon.com/kms/latest/APIReference/API_KeyMetadata.html)
+- [AWS IAM `ListPolicies` `Scope`](https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListPolicies.html)
+- [Azure managed identity types](https://learn.microsoft.com/en-us/azure/app-service/overview-managed-identity)
+- [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)
+- [WorkOS roles (`EnvironmentRole | OrganizationRole`)](https://workos.com/docs/reference/roles/role)
+- [Clerk directory sync attribute locking](https://clerk.com/docs/guides/configure/auth-strategies/enterprise-connections/directory-sync)
+- [Zitadel system API users](https://zitadel.com/docs/guides/integrate/zitadel-apis/access-zitadel-system-api)

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -129,9 +129,14 @@ taxonomy dictates its value structure:
   make `managed_by` immutable and `system` rows undeletable.
 
 Open point while this ADR is in review: the api-side value, `api`
-(precedented channel word) versus `principal` (unprecedented actor word).
-The taxonomy proves these are the only two candidates; it does not pick
-between them.
+(channel word, precedented by Grafana's literal `provenance: api` value)
+versus `principal` (actor word). The taxonomy proves these are the only
+two candidates. The cloud deep survey (below) shifted the evidence:
+`principal` is the official umbrella actor term at all three major clouds
+(AWS glossary, Azure "security principal", GCP's explicit
+members-to-principals rename), so it is no longer unprecedented as
+vocabulary, only as an enum value in a managed-by field. `api` retains
+the only exact-position precedent.
 
 ### Precedent survey (2026-08-03)
 
@@ -163,8 +168,130 @@ locks, missing endpoints, config-time auth with no data marking); a single
 inspectable, trigger-enforceable column is more general than any surveyed
 implementation.
 
+### Cloud-provider deep survey (AWS, GCP, Azure; primary sources, verified 2026-08-03)
+
+A second research pass fetched official API references directly. Every
+row below is verbatim-verified against the cited page; claims that could
+not be confirmed verbatim were dropped or are marked as such.
+
+#### AWS
+
+| Where | Field | Exact values | Enforcement |
+| --- | --- | --- | --- |
+| KMS `KeyMetadata` | `KeyManager` | `AWS`, `CUSTOMER` | AWS-managed keys: no property changes, no policy changes, no deletion scheduling, rotation fixed |
+| IAM `ListPolicies` | `Scope` | `All`, `AWS`, `Local` | "You cannot change the permissions defined in AWS managed policies" |
+| IAM service-linked roles | path `/aws-service-role/` | structural | admins "can view, but not edit the permissions"; deletion only via the dedicated `DeleteServiceLinkedRole` API |
+| EventBridge `DescribeRule` | `ManagedBy` | service principal name | "created by an AWS service on your behalf... displays the principal name of the AWS service that created the rule"; `DisableRule`, `EnableRule`, `PutRule`, `PutTargets`, `TagResource`, `UntagResource` are rejected with no override; only `DeleteRule`/`RemoveTargets` accept an explicit `Force` |
+| Config `Source` | `Owner` | `AWS`, `CUSTOM_LAMBDA`, `CUSTOM_POLICY` | "Indicates whether AWS or the customer owns and manages the AWS Config rule" |
+| Organizations `PolicySummary` | `AwsManaged` | boolean | "you can attach the policy... but you cannot edit it" |
+| Secrets Manager | `OwningService` | service id string | "Managed secrets can only be created by the AWS service that manages them"; `DeleteSecret` raises `InvalidRequestException` |
+| EC2 managed prefix lists | owner | `AWS` | "You cannot create, modify, share, or delete an AWS-managed prefix list" |
+| Cross-service tags | reserved `aws:` key prefix | prefix | "you can't edit or delete the tag's key or value" |
+
+Actor vocabulary: IAM's glossary makes **Principal** the umbrella term
+("An AWS account root user, IAM user or an IAM role... Principals include
+human users, workloads, federated principals, and assumed roles"), with
+**service principal** (`{service}.amazonaws.com`) as the named form for
+software actors.
+
+#### GCP
+
+| Where | Field / mechanism | Exact values | Enforcement |
+| --- | --- | --- | --- |
+| Compute `sslCertificates` | `type` | `MANAGED`, `SELF_MANAGED` ("Google-managed SSLCertificate." / "Certificate uploaded by user.") | `managed.status` output-only |
+| Certificate Manager | union `managed` / `selfManaged` / `managedIdentity` | structural | managed cert `domains`, `dnsAuthorizations`, `issuanceConfig` marked "Immutable" |
+| Storage/BigQuery encryption tiers | field presence (`kmsKeyName`, `customerEncryption`) | none | Google-managed is the absence of both; no enum anywhere |
+| IAM predefined roles | `roles/*` namespace | structural | predefined/basic roles "always have the ETag `AA==`" |
+| Cloud Logging | bucket ids `_Required`, `_Default` | structural | "You can't change the retention period of the `_Required` log bucket" |
+| Org Policy | "managed constraints" vs custom | prose | custom constraints "are managed by your organization instead of by Google" |
+| Dataproc | reserved `goog-dataproc-*` label keys | structural | auto-applied; overriding "not recommended" |
+| App Engine | default service | none | "You can't delete the default app" |
+| GKE Autopilot | "GKE Warden" admission | denial message | `GKE Warden authz [denied by managed-namespaces-limitation]` on GKE-managed namespaces |
+| Literal `managedBy` field | searched Filestore, Cloud SQL, GKE NodePool schemas | absent | GCP has no literal `managedBy` API field; the `app.kubernetes.io/managed-by` label is an upstream Kubernetes convention, not a GCP schema field |
+
+Actor vocabulary: GCP's IAM docs use **principals** as the umbrella and
+say so explicitly ("In the past, principals were referred to as
+_members_. Some APIs still use that term"); workload/workforce federation
+identifies actors by `principal://` and `principalSet://` URIs. Note the
+prose/schema divergence: the Policy binding field is still literally
+`members`. Service agents are marked only by a naming convention
+(`service-PROJECT_NUMBER@gcp-sa-*`), with no schema field, and the docs
+warn their role permissions "can change without notice".
+
+#### Azure / Entra
+
+| Where | Property | Exact values | Enforcement |
+| --- | --- | --- | --- |
+| ARM resources and resource groups | `managedBy` | resource id | "ID of the resource that manages this resource"; enforcement is delivered separately via deny assignments, not by the field itself |
+| Deny assignments | `isSystemProtected` | boolean | "You can't directly create your own deny assignments. Deny assignments are created and managed by Azure"; "created by Azure and cannot be edited or deleted"; currently all deny assignments are system protected |
+| Azure Policy definitions | `policyType` | `NotSpecified`, `BuiltIn`, `Custom`, `Static` | "The policyType property can't be set" (server-assigned); `Static` denotes Microsoft ownership |
+| RBAC role definitions | `type`/`roleType` | `BuiltInRole`, `CustomRole` | built-ins copied, not edited |
+| Graph `servicePrincipal` | `servicePrincipalType` | `Application`, `ManagedIdentity`, `Legacy`, `ServiceIdentity`, `SocialIdp` | `ManagedIdentity`: "can be granted access and permissions, but can't be updated or modified directly" |
+| ARM `identity` | `type` | `SystemAssigned`, `UserAssigned`, `SystemAssigned, UserAssigned`, `None` | system-assigned lifecycle tied to the resource; "Azure automatically deletes the service principal for you" |
+| Graph `user` | `onPremisesSyncEnabled` + synced attributes | boolean | "the source of authority for this set of properties is the on-premises and is read-only" |
+| Entra hybrid identity | **Source of Authority (SOA)** | concept + per-object conversion | converting Group/User SOA to cloud makes the object cloud-editable: a first-party precedent for authority *transfer* |
+| Graph `unifiedRoleDefinition` | `isBuiltIn` | boolean | "Read-only"; cascades read-only onto description, permissions, scopes when true |
+| Graph `user` | `creationType` | `null`, `Invitation`, `LocalAccount`, `EmailVerified`, `SelfServiceSignUp` | "Read-only": a pure provenance field, coexisting with SOA (authority), proving the two axes are distinct in the wild |
+| AKS | node resource group lockdown | `ReadOnly`, `Unrestricted` | "a deny assignment blocks direct updates" under `ReadOnly` |
+| Event Grid | `systemTopics` resource type | structural | "Only Azure services can publish events to system topics" |
+
+Actor vocabulary: "A **security principal** is an object that represents
+a user, group, service principal, or managed identity that is requesting
+access" (RBAC overview); **tenant** is Entra's word for the directory
+boundary. Honesty note: `systemData.createdByType` enumerates `User`,
+`Application`, `ManagedIdentity`, `Key` and has no `System` value despite
+the field's name; Azure carries the system-owned concept in booleans
+(`isSystemProtected`, `isBuiltIn`) and value prefixes (`SystemAssigned`),
+never as a bare `system` enum token.
+
+#### What the deep survey establishes
+
+1. **An authority-named enum on the resource is a first-class industry
+   pattern**: AWS `KeyManager`/`Source.Owner`/`AwsManaged`, Azure
+   `policyType`/`roleType`/`managedBy`, GCP `sslCertificates.type`. GCP's
+   own field-presence approach for encryption tiers is the
+   counter-example that shows why the explicit enum is the cleaner shape.
+2. **Enforcement is verb-level, not decorative**, in every mature
+   implementation: AWS rejects specific mutation calls outright (some
+   with explicit `Force` escape hatches, identity resources with a
+   dedicated deletion API), Azure enforces via system-protected deny
+   assignments. This matches pairing the field with API-layer rejections
+   and database triggers rather than treating it as informational.
+3. **The literal token `system` is this taxonomy's own choice**: AWS's
+   token is `AWS`, GCP's is `MANAGED`, Azure's are `BuiltIn`/`Static`/
+   `SystemAssigned`/`isSystemProtected`. Each provider names itself; a
+   self-hosted product has no vendor name to use, and `system` is the
+   generic form of what `SystemAssigned`, `isSystemProtected`, and
+   "system topics" already gesture at.
+4. **`principal` is the one actor word all three clouds share** as their
+   official umbrella for authenticated identities (AWS glossary, Azure
+   "security principal", GCP's explicit members-to-principals rename).
+   This is the strongest evidence in the whole survey for the ladder's
+   union term, and it strengthens `principal` as a viable api-side value
+   relative to where the earlier survey left it.
+5. **Azure's Source of Authority is the flagship precedent for the
+   `external` rung and for rule 4**: externally-mastered objects are
+   read-only locally, the concept is named for *authority* (not
+   provenance), and Microsoft ships authority *transfer* (SOA conversion)
+   as a supported operation, while keeping a separate read-only
+   `creationType` field for actual provenance.
+
 ## Links
 
+- [AWS EventBridge `ManagedBy` (DescribeRule)](https://docs.aws.amazon.com/eventbridge/latest/APIReference/API_DescribeRule.html)
+- [AWS Config `Source.Owner`](https://docs.aws.amazon.com/config/latest/APIReference/API_Source.html)
+- [AWS Organizations `PolicySummary.AwsManaged`](https://docs.aws.amazon.com/organizations/latest/APIReference/API_PolicySummary.html)
+- [AWS Secrets Manager managed secrets (`OwningService`)](https://docs.aws.amazon.com/secretsmanager/latest/userguide/service-linked-secrets.html)
+- [AWS IAM terms (Principal umbrella)](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_identity-management.html)
+- [Azure ARM `managedBy`](https://learn.microsoft.com/en-us/rest/api/resources/resource-groups/get?view=rest-resources-2021-04-01)
+- [Azure deny assignments (`isSystemProtected`)](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments)
+- [Azure Policy `policyType`](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/definition-structure-basics)
+- [Entra Source of Authority overview](https://learn.microsoft.com/en-us/entra/identity/hybrid/concept-source-of-authority-overview)
+- [Azure RBAC overview (security principal)](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview)
+- [GCP `sslCertificates.type` (MANAGED | SELF_MANAGED)](https://cloud.google.com/compute/docs/reference/rest/v1/sslCertificates)
+- [GCP IAM overview (members renamed to principals)](https://docs.cloud.google.com/iam/docs/overview)
+- [GCP service agents](https://docs.cloud.google.com/iam/docs/service-agents)
+- [GKE Autopilot managed-namespace enforcement](https://docs.cloud.google.com/kubernetes-engine/security/autopilot-cluster-policies-standard)
 - [Okta policy API (`system` attribute)](https://developer.okta.com/docs/api/openapi/okta-management/management/tags/policy/)
 - [Grafana alerting provisioning (`provenance`)](https://grafana.com/docs/grafana/latest/alerting/set-up/provision-alerting-resources/)
 - [AWS KMS `KeyManager`](https://docs.aws.amazon.com/kms/latest/APIReference/API_KeyMetadata.html)

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -66,9 +66,13 @@ Channels are orthogonal to actors and must never be confused with them:
 
 | Channel | Meaning |
 | --- | --- |
-| `config` | Declared deployment configuration, converged by `system` |
+| `declaration` | The deployment declares desired state and `system` converges it. Transport-agnostic on purpose: env vars, values files, a declared public key, or federation trust are all declarations. Rejected names for this channel: `file` (Grafana's word; misleading, a declaration need not be a file), `config` (names an overloaded artifact, not the way a write arrives), `provisioning`/`provisioned` (collides with SCIM user provisioning, which is the `sync` channel) |
 | `api` | The single governed management surface; every management client (console, CLI appliers, Terraform/Crossplane providers) is a client of it, never a backdoor |
 | `sync` | Inbound replication from an `external` system of record |
+
+Note the axis discipline this table enforces: `declaration` was rejected
+as an authority value (it names how, not who), yet it is exactly right as
+a channel name, where "how" is the axis being named.
 
 ### Reserved words (one meaning each)
 

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -53,6 +53,13 @@ Two structural notes:
   rows read-only through the product's own surfaces, for opposite
   reasons).
 
+A sibling authority sits beside the ladder rather than on it: the
+**release** (resources defined by the software itself: default roles,
+sentinel rows, reserved permissions). Built-in resources are documented
+separately in [ADR#0289186035](../0289186035/README.md), including the
+six modes in which built-in-ness applies and when a `builtin` value joins
+a `managed_by`-style enum.
+
 ### The channel axis (how a write arrives)
 
 Channels are orthogonal to actors and must never be confused with them:

--- a/src/adrs/8779742261/README.md
+++ b/src/adrs/8779742261/README.md
@@ -1,148 +1,167 @@
 ---
 id: '8779742261'
-title: Naming the Mutation-Authority Field on System-Converged Resources
+title: Actor and Authority Taxonomy for Managed Systems
 state: Reviewing
 created: 2026-08-03
-tags: [naming, schema, authorization, gitops, identity]
+tags: [naming, taxonomy, schema, authorization, gitops, identity]
 category: Platform
 ---
 
-# Naming the Mutation-Authority Field on System-Converged Resources
+# Actor and Authority Taxonomy for Managed Systems
 
 ## Context
 
-A recurring design in our systems: some rows of a resource table are
-converged by the server itself from declared deployment configuration (for
-example, a GitOps operator service account and its API keys, created and
-kept in sync on every boot), while the rest are created and mutated by API
-callers. The converged rows must be read-only through the API: their single
-source of truth is the declaration, and every rule that touches them asks
-exactly one question:
+Multi-tenant products keep needing to answer the same question in schemas,
+enums, role names, and docs: **who is acting, and with what authority?**
+Without a shared taxonomy, each field invents its own vocabulary, and the
+same words drift across meanings: "system" sometimes means the software,
+sometimes the deployment; "platform" sometimes means the product,
+sometimes the management plane; "operator" sometimes means a human,
+sometimes an automation; "user" sometimes means any caller, sometimes the
+end user. A concrete casualty: a mutation-authority field first shipped as
+`origin: config | api` and had to be renamed twice because neither word
+had an agreed meaning.
 
-> **Which authority is allowed to mutate this row?**
+This ADR fixes the vocabulary once: a ladder of actors, a set of channels,
+the reservation rules for the words involved, and a worked application to
+the recurring "system-converged, read-only through the API" pattern.
 
-The field answering that question needs a name and values. A first attempt
-shipped as `origin` with values `config | api` and did not survive contact:
-in an identity product, `origin` is saturated vocabulary for the
-scheme-host-port web concept (CORS, WebAuthn, trusted origins), and
-`config` names where a row came from rather than anything the system ever
-checks. The renaming journey (`origin`, `declaration`, `deployment_config`,
-`provenance`, `managed_by`) showed the decision deserves a record: what
-criteria must the name satisfy, and why each candidate lives or dies.
+## Resolution
 
-### Decision criteria
+Chosen option: "a five-rung actor ladder plus an orthogonal channel axis,
+with reserved one-meaning words", because every naming dispute encountered
+so far reduces to either confusing two rungs of the ladder, confusing an
+actor with a channel, or reusing a word that already had a meaning.
 
-1. **Name the intent, not a mechanism, not history, not a derived
-   property.** The intent is the standing mutation authority. This rules
-   out provenance-flavored names (history), mechanism names that go stale
-   when the declaration transport changes (env-declared hashes today,
-   declared public keys or federation trust later), and derived-property
-   names like `read_only` or `immutable` (the row is mutable, just not by
-   the API; "immutable for whom" is exactly the ambiguity to avoid).
-2. **Every value must be true for every row in its class.** The
-   API-governed class contains rows created by humans, by service
-   accounts, and by infrastructure-as-code controllers; any value naming a
-   specific actor is false for part of the class.
-3. **Enum, not boolean.** A third authority is plausible (SCIM- or
-   directory-synced users, federation-provisioned principals); an enum
-   absorbs it as a new value, a boolean forces a breaking reshape.
-4. **Survive authority transfer.** Adoption is a bread-and-butter GitOps
-   move (`terraform import`, Crossplane observe-and-adopt): a row created
-   through the API comes under configuration management later. A field
-   named for history cannot record that honestly; a field named for
-   authority can.
-5. **No collisions with the schema's loaded vocabulary.** In an identity
-   product this reserves `origin` (web origin), `owner`/`owned_by` (which
-   principal a credential belongs to), `client` (OAuth), `user` (the users
-   table), `tenant`, and `operator` (both the converged service account
-   itself and the human running the deployment).
+### The actor ladder (who can cause a write)
+
+| Rung | Meaning | Trust source | Examples |
+| --- | --- | --- | --- |
+| `system` | The software itself, acting autonomously with **no principal attached** | The deployment's trust root (declared configuration, master keys) | Boot-time convergence of declared resources, migrations, internal schedulers |
+| `platform` | Principals whose scope is the **whole deployment**, across every tenant | Grants in the management plane | Platform administrators, a config-declared operator service account |
+| `tenant` | Principals scoped to **one customer organization** | Grants inside that organization | Org admins, org members managing org resources |
+| `user` | An individual principal acting on **their own resources** | Self-service capability | Own profile, own API keys, own MFA enrollment |
+| `external` | An **outside system of record**; its writes arrive by synchronization and are read-only from inside | The sync trust relationship | SCIM/directory-synced users, upstream-IdP-asserted attributes |
+
+Two structural notes:
+
+- `system` is the only rung with no principal. Everything from `platform`
+  down acts as an authenticated principal under the product's capability
+  model.
+- `external` is the only rung whose authority lives outside the
+  deployment entirely; it is the inbound mirror of `system` (both make
+  rows read-only through the product's own surfaces, for opposite
+  reasons).
+
+### The channel axis (how a write arrives)
+
+Channels are orthogonal to actors and must never be confused with them:
+
+| Channel | Meaning |
+| --- | --- |
+| `config` | Declared deployment configuration, converged by `system` |
+| `api` | The single governed management surface; every management client (console, CLI appliers, Terraform/Crossplane providers) is a client of it, never a backdoor |
+| `sync` | Inbound replication from an `external` system of record |
+
+### Reserved words (one meaning each)
+
+- `system`: the software itself (ladder rung 1). Never "the whole product".
+- `platform`: the deployment-wide management plane (rung 2). Never the
+  product as a whole.
+- `tenant`: the customer-organization boundary (rung 3). Preferred over
+  `customer` (billing-flavored, ambiguous between rung 3 and "whoever
+  bought the software") and over `organization` where a shorter word is
+  viable.
+- `user`: an individual end principal (rung 4). Never "any API caller".
+- `principal`: any authenticated identity (human or service account)
+  acting through governed surfaces; the union of rungs 2 to 4.
+- `external`: rung 5 only.
+- `operator` unqualified: **banned**. Say "operator service account" (a
+  specific rung-2 automation principal) or "infrastructure operator" (the
+  human controlling the deployment); the bare word has meant both and
+  caused real confusion.
+- `client`: OAuth/OIDC client only.
+- `origin`: the web scheme-host-port concept only.
+- `customer`: avoid in schemas; see `tenant`.
+- `owner`/`owned_by`: resource-to-principal belonging (whose credential
+  this is), never mutation authority.
+
+### Naming rules derived from the taxonomy
+
+1. Name fields for the axis they check: an authority field names actors
+   (or the actor-channel shorthand below), a transport field names
+   channels, a scope field names boundaries. Never mix axes in one enum
+   without noticing you are doing it.
+2. A value must be true for every row in its class. Corollary: a class
+   that is the union of several ladder rungs cannot be named after any
+   single rung; it must be named by what the union shares.
+3. Prefer enums over booleans for authority: new rungs and new external
+   authorities arrive as new values, not as breaking reshapes.
+4. Authority can transfer (GitOps adoption: `terraform import`,
+   observe-and-adopt); history cannot. Fields that drive standing rules
+   name authority (`managed_by`), never history (`provenance`, `source`,
+   `origin`), and `provenance` stays reserved for genuinely historical
+   records (audit, supply-chain attestation).
+
+### Worked application: the mutation-authority field
+
+The recurring pattern: rows converged by `system` from declared
+configuration must be read-only through the API, alongside ordinary rows
+governed by principals. The field is named **`managed_by`**, and the
+taxonomy dictates its value structure:
+
+- The converged class is exactly rung 1: value **`system`**.
+- The other class is the union of rungs 2, 3, and 4 (platform, tenant,
+  and user principals all mutate through the same governed surface). By
+  rule 2 it cannot be called `platform`, `customer`, or `user`; the only
+  honest names are what the union shares: **`api`** (the channel every
+  member acts through, per the single-management-surface rule) or
+  **`principal`** (the actor category every member belongs to). Industry
+  precedent exists only for the channel word (Grafana Alerting's
+  `provenance` enum uses the literal value `api` for this class; Okta
+  marks the converged class with `system`); `principal` is the
+  grammatically agent-shaped alternative with no precedent.
+- Future authorities join as values, per rule 3: directory-synced rows
+  arrive as `managed_by: external` (or a finer-grained `scim`), not as a
+  stretched reading of an existing value.
+- Enforcement keys off the field at every layer: API writes rejected on
+  `system` rows, converge logic writes them freely, database triggers
+  make `managed_by` immutable and `system` rows undeletable.
+
+Open point while this ADR is in review: the api-side value, `api`
+(precedented channel word) versus `principal` (unprecedented actor word).
+The taxonomy proves these are the only two candidates; it does not pick
+between them.
 
 ### Precedent survey (2026-08-03)
 
 | Product | Field | Values | Behavior |
 | --- | --- | --- | --- |
 | Okta (policies, network zones) | `system` | boolean | system rows undeletable; "created by a system or by a user" |
-| Grafana Alerting | `provenance` | `none`, `api`, `file` | file-provisioned rows locked from the API surface; escape via `X-Disable-Provenance` header |
+| Grafana Alerting | `provenance` | `none`, `api`, `file` | file-provisioned rows locked from the API surface |
 | Grafana dashboards | `meta.provisioned` | boolean | provisioned dashboards read-only in UI |
 | AWS KMS | `KeyManager` | `AWS`, `CUSTOMER` | AWS-managed keys not editable |
 | AWS IAM | `Scope` | `AWS`, `Local` | AWS-managed policies copy-to-edit only |
 | Azure RBAC | `type` | `BuiltInRole`, `CustomRole` | built-ins read-only |
 | Azure managed identity | `identity.type` | `SystemAssigned`, `UserAssigned` | agent-pair naming of the same boundary |
-| GCP | none | none | Google-managed vs customer-managed expressed structurally (field presence) and by naming conventions, no enum |
+| GCP | none | none | Google-managed vs customer-managed expressed structurally, no enum |
 | Kubernetes | `app.kubernetes.io/managed-by` | free-form label | convention only, unenforced |
 | Salesforce | `custom` | boolean | standard vs custom objects |
-| WorkOS (roles) | `type` | `EnvironmentRole`, `OrganizationRole` | row-level system-vs-custom enum; default environment role undeletable while default |
-| WorkOS (directory sync) | none | none | structurally read-only: no mutation endpoints exist; writes flow only from the source directory |
-| Clerk | none (presence of enterprise-connection record) | connection `provider`/`protocol` | directory-synced attributes documented read-only; system permissions marked only by a key-prefix convention |
-| Zitadel | none | none | runtime config declares config-only API principals (self-signed JWT against a declared public key) but marks nothing in the data model; bootstrap-created rows indistinguishable afterward |
+| WorkOS (roles) | `type` | `EnvironmentRole`, `OrganizationRole` | row-level system-vs-custom enum |
+| WorkOS (directory sync) | none | none | structurally read-only: no mutation endpoints exist |
+| Clerk | none (enterprise-connection presence) | connection `provider`/`protocol` | directory-synced attributes documented read-only |
+| Zitadel | none | none | config-declared API principals exist but nothing is marked in the data model |
 | Keycloak | none | none | built-ins protected by convention only |
 
-Two shapes dominate: a boolean `system` flag (Okta, Salesforce, Grafana
-dashboards) and a two-value ownership enum (AWS, Azure, Grafana Alerting,
-WorkOS roles). The cloud providers name agent pairs (`AWS | CUSTOMER`,
-system-assigned vs user-assigned), which works because a cloud provider
-and its customer really are two parties; self-hosted software has no such
-split, because the installing organization writes the deployment
-configuration and calls the API. Keycloak's nothing-at-all is the failure
-mode the field exists to avoid; Kubernetes' free-form label is the wrong
-shape for a closed two-class rule; the adjacent identity products (Clerk,
-WorkOS, Zitadel) validate the concept everywhere while fragmenting the
-shape (behavioral locks, missing endpoints, config-time auth with no data
-marking), so a single inspectable, trigger-enforceable column is more
-general than any surveyed implementation.
-
-## Resolution
-
-Chosen option: **`managed_by`, an enum with values `system | api`**,
-because it is the only candidate that satisfies every criterion: it names
-the standing authority rather than a mechanism or history (criterion 1),
-its values are true for every row in their class (criterion 2), the enum
-absorbs future authorities such as `scim` or `federation` (criterion 3),
-authority transfer on adoption is an honest update rather than a rewritten
-history (criterion 4), and neither word collides with the schema's loaded
-vocabulary (criterion 5).
-
-- **`system`** names the authority that converges declared rows: the
-  server acting on its own trust root, whatever the declaration mechanism
-  is. Okta marks exactly this class with `system`.
-- **`api`** names the only thing true of every row in the other class: it
-  is governed through the management API's capability model, by whichever
-  principal holds capability. It is a channel word rather than an agent
-  word, a deliberate asymmetry: the class has no single agent (criterion
-  2). It leans on the platform rule that the management API is the single
-  management surface with no backdoors (every management client, console,
-  CLI applier, or IaC provider, is a client of that surface), so there is
-  no third write path for the value to be wrong about. Grafana Alerting
-  uses the literal value `api` for the same class.
-- Enforcement follows the field at every layer: the API rejects writes on
-  `system` rows, the converge logic writes them freely, and database
-  triggers make `managed_by` immutable and `system` rows undeletable, so
-  ownership can be neither promoted nor laundered.
-
-Rejected alternatives:
-
-| Candidate | Kills it |
-| --- | --- |
-| `origin: config \| api` | `origin` collides with web-origin vocabulary; `config` names provenance, not authority (criteria 1, 5) |
-| `source`, `provenance` | Name history, not the standing rule; break on adoption (criterion 4): a hand-created row brought under configuration management keeps its provenance but changes its authority. Grafana's own escape header shows `provenance` behaving as misnamed authority. `provenance` is also vocabulary audit and supply-chain features (SLSA) want with its literal meaning |
-| `declaration`, `deployment_config` as the system-side value | Name today's mechanism; go stale when the declaration transport changes (criterion 1) |
-| `operator` as the system-side value | Self-referential: the operator service account is the row being managed, and rows the operator creates through the API belong to the other class (criterion 5) |
-| boolean `system` flag | Cannot grow a third authority without a breaking reshape (criterion 3) |
-| `platform \| customer` (the cloud-provider agent pair) | Right split read as roles (infrastructure-operator hat vs product-user hat), unusable words: `platform` reads as the product's platform/management plane, so rows platform admins create via the API would carry the opposite value; `customer` means tenant organizations in a multi-tenant identity product (criteria 2, 5) |
-| `user`, `customer`, `manual`, `client` as the api-side value | Each is false for part of the class (IaC-created rows are not `user`/`manual`; platform-scoped rows are not `customer`) or collides (`client` = OAuth client, `user` = users table) (criteria 2, 5) |
-| `management_api` as the api-side value | Semantically identical to `api`, strictly more verbose; acceptable fallback if the bare `api` proves confusing in practice |
-| `principal` as the api-side value | The one coherent agent word ("managed by a principal through the management surface"); grammatically reads like a dangling reference to a specific principal, and has no precedent anywhere surveyed; kept as the named alternative if `api` proves confusing in practice |
-| `owned_by` / `owner` as the column | Credential ownership already means something else on the same tables; a second ownership recreates the `origin` problem (criterion 5) |
-
-On reserving `managed_by` for a future domain concept: considered and
-rejected as a reason to pick a different name. Business-level ownership
-axes already have names (credential owner, team placement), a
-"managed by organization X" feature would want a reference column rather
-than a closed enum, and surveyed identity products name that concept
-differently anyway (Entra `onPremisesSyncEnabled`/`creationType`, Okta
-`credentials.provider`). If a synced-user feature lands later, it is the
-same mutation-authority concept and joins this field as a new value
-(`scim`, `federation`) rather than colliding with it.
+The cloud providers name agent pairs (`AWS | CUSTOMER`, system-assigned vs
+user-assigned), which works because provider and customer really are two
+parties; in self-hosted software the installing organization plays both
+roles (writes the configuration and calls the API), so the boundary must
+be named by ladder rungs, not by legal parties. The identity products
+validate the concept everywhere while fragmenting the shape (behavioral
+locks, missing endpoints, config-time auth with no data marking); a single
+inspectable, trigger-enforceable column is more general than any surveyed
+implementation.
 
 ## Links
 

--- a/src/adrs/9870790320/README.md
+++ b/src/adrs/9870790320/README.md
@@ -1,0 +1,123 @@
+---
+id: '9870790320'
+title: Mutability Is Contract or Input, Never Stored Output
+state: Approved
+created: 2026-08-03
+tags: [schema, api-design, mutability, naming, taxonomy]
+category: Platform
+---
+
+# Mutability Is Contract or Input, Never Stored Output
+
+## Context
+
+Once a mutation-authority field exists
+([ADR#8779742261](../8779742261/README.md)), the same design itch recurs:
+"should we also add `immutable: true`? or `deletable: false`?" The itch is
+understandable, the answer is no, and the major API platforms have a
+per-se convention that says exactly where each kind of mutability
+knowledge belongs. This ADR records that convention so the question stops
+being re-asked per product.
+
+The core confusion is between three different kinds of fact that all get
+casually called "immutability":
+
+1. A **field-level rule**: "this property can never change after
+   creation" (true for every row).
+2. A **row-level derived capability**: "this particular row cannot be
+   deleted right now" (a conclusion computed from authority, invariants,
+   and flags).
+3. A **row-level independent input**: "the owner asked for a safety latch
+   on this row" (a fact someone set, derivable from nothing).
+
+Storing kind 1 or kind 2 as a column creates a second source of truth for
+a rule that already has one, makes contradictory states representable
+(`managed_by: system, immutable: false`?), and flattens many causes with
+many remedies into a single unexplained bit.
+
+## Resolution
+
+Chosen option: "declare field rules in the API contract, compute derived
+capabilities into responses, store only independent inputs", because this
+is verifiably what the platform vendors themselves do, and it is the only
+arrangement in which no stored value can drift from the rule it
+describes.
+
+### 1. Field-level mutability is API-contract metadata
+
+Google's public API rulebook (the AIP system, google.aip.dev) defines
+`google.api.field_behavior` annotations declared on the field in the
+contract, not stored in any row: `IMMUTABLE` ("A field on a resource
+cannot be changed after its creation"), `OUTPUT_ONLY` ("The field is
+provided in responses, but... including the field in a message in a
+request does nothing"), `INPUT_ONLY`, `REQUIRED`, `IDENTIFIER` (AIP-203).
+Azure's equivalent is the `x-ms-mutability` OpenAPI extension, an array
+of `create` | `read` | `update` on the property definition, e.g.
+`"x-ms-mutability": ["create", "read"]` for a set-once property.
+
+Applied to a mutation-authority field: `managed_by` is contract-level
+`IMMUTABLE` (its value is assigned at birth and never changes through the
+API), declared in the OpenAPI/schema definition, enforced by the API
+layer, and backstopped by database triggers
+([ADR#8779742261](../8779742261/README.md)). Nothing about that requires
+or tolerates a per-row `immutable` column.
+
+### 2. Row-level derived capabilities are computed response fields
+
+"Can this row be deleted?" is a question whose answer is derived at
+request time from the authority field, invariants (e.g. a last-admin
+guard), protection flags, and referential integrity. The precedented
+shape is a computed, read-only field in the API response (the
+`viewerCanDelete` pattern; in AIP terms, an `OUTPUT_ONLY` field), so a
+client can gray out a button without the server ever persisting the
+conclusion. A stored `deletable` column is this pattern done wrong: it
+conflates causes (system-managed? protected? blocked by an invariant?)
+and goes stale the moment any input changes.
+
+### 3. Row-level independent inputs are stored flags
+
+The only mutability-adjacent facts that belong in storage are the ones
+that are inputs, set by an authority and derivable from nothing:
+
+- **Owner safety latches**: GCP's `deletionProtectionEnabled` (verified
+  on Filestore instances), AWS termination protection. The owner sets it,
+  the owner clears it, deletion checks read it.
+- **Per-object reconciliation opt-outs**: Kubernetes'
+  `rbac.authorization.k8s.io/autoupdate: "false"` annotation on default
+  RBAC objects ([ADR#0289186035](../0289186035/README.md), mode 3).
+
+The test for any proposed flag: **is it an independent degree of freedom
+someone sets, or is it derivable from existing fields?** Store inputs;
+compute outputs; never store an output next to its inputs.
+
+### Which vendor to follow, per se
+
+Google is the only major cloud that publishes a complete, versioned,
+public rule system for these questions (the AIPs: resource names in
+AIP-122, field behavior in AIP-203), and its rules are the ones this ADR
+adopts where they exist. Azure's REST guidelines and `x-ms-mutability`
+corroborate the same split (contract metadata, not row data) and serve as
+the second reference. AWS exhibits the same patterns in its APIs
+(verb-level rejections for system-managed resources, attribution fields,
+stored protection toggles) but publishes no equivalent public rulebook,
+so it serves as pattern evidence rather than a rule source.
+
+### Summary decision table
+
+| Fact | Where it lives | Precedent |
+| --- | --- | --- |
+| "This field never changes after create" | API contract annotation (`IMMUTABLE` / `x-ms-mutability`), enforced at the write path, DB triggers as backstop | AIP-203, Azure autorest |
+| "This row is owned by X" | The stored authority enum (`managed_by`) | ADR#8779742261 |
+| "Can the caller delete/edit this row right now" | Computed `OUTPUT_ONLY` response field | `viewerCan*` pattern, AIP-203 |
+| "The owner asked for a deletion guard" | Stored boolean input flag | GCP `deletionProtectionEnabled`, AWS termination protection |
+| "Skip reconciling this built-in object" | Stored per-object opt-out marker | Kubernetes `autoupdate` annotation |
+| "This row is read-only" as a stored column | Nowhere, ever | The anti-pattern this ADR exists to reject |
+
+## Links
+
+- [ADR#8779742261: Actor and Authority Taxonomy](../8779742261/README.md)
+- [ADR#0289186035: Built-In Resources and Their Modes](../0289186035/README.md)
+- [AIP-203: Field behavior documentation](https://google.aip.dev/203)
+- [AIP-122: Resource names](https://google.aip.dev/122)
+- [Azure autorest `x-ms-mutability`](https://github.com/Azure/autorest/blob/main/docs/extensions/readme.md)
+- [Kubernetes default RBAC auto-reconciliation](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)


### PR DESCRIPTION
- Schemas, enums, role names, and docs keep re-answering the same question (who is acting, with what authority) with drifting vocabulary; a mutation-authority field had to be renamed twice because of it. The taxonomy ADR fixes the vocabulary once: a five-rung actor ladder (system, platform, tenant, user, external), an orthogonal channel axis (declaration, api, sync), one-meaning word reservations, and a worked application to the managed_by field, all backed by verbatim-verified surveys of AWS, GCP, Azure, and the adjacent identity products.
- The companion built-in ADR separates the sibling concept the taxonomy kept colliding with: resources defined by the release itself rather than by deployment configuration, applied in six verified modes (immutable, editable-except-core, reconciled-on-boot, delete-protected-but-configurable, seeded-but-unprotected, code-constant) with selection guidance, because declaring something built-in without declaring its mode leaves enforcement undefined.
- Both ADRs are Approved: the mutation-authority field resolves as managed_by: system | principal (api rejected as an axis-mixing channel word in an actor-headed enum, despite the Grafana exact-position precedent).

